### PR TITLE
Sending empty arrays or dictionaries may raise an exception

### DIFF
--- a/socketio/packet.py
+++ b/socketio/packet.py
@@ -135,11 +135,6 @@ class Packet(object):
         else:
             return data
 
-
-
-
-
-
     def _data_is_binary(self, data):
         """Check if the data contains binary components."""
         try:

--- a/socketio/packet.py
+++ b/socketio/packet.py
@@ -135,17 +135,25 @@ class Packet(object):
         else:
             return data
 
+
+
+
+
+
     def _data_is_binary(self, data):
         """Check if the data contains binary components."""
-        if isinstance(data, six.binary_type):
-            return True
-        elif isinstance(data, list):
-            return functools.reduce(
-                lambda a, b: a or b, [self._data_is_binary(item)
-                                      for item in data])
-        elif isinstance(data, dict):
-            return functools.reduce(
-                lambda a, b: a or b, [self._data_is_binary(item)
-                                      for item in six.itervalues(data)])
-        else:
+        try:
+            if isinstance(data, six.binary_type):
+                return True
+            elif isinstance(data, list):
+                return functools.reduce(
+                    lambda a, b: a or b, [self._data_is_binary(item)
+                                          for item in data])
+            elif isinstance(data, dict):
+                return functools.reduce(
+                    lambda a, b: a or b, [self._data_is_binary(item)
+                                          for item in six.itervalues(data)])
+            else:
+                return False
+        except TypeError:
             return False


### PR DESCRIPTION
eg. **emit('test message',{})** will fail due to functools.reduce doesn't support empty sequences. This fix seems to work for me flawlessly, maybe you will find a more elegant solution.