### PR TITLE
Multiple workers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ Features
   assigned to "rooms".
 - Optional support for multiple servers, connected through a messaging queue
   such as Redis or RabbitMQ.
+- Send messages to clients from external processes, such as Celery workers or
+  auxiliary scripts.
 - Event-based architecture implemented with decorators that hides the details
   of the protocol.
 - Support for HTTP long-polling and WebSocket transports.

--- a/README.rst
+++ b/README.rst
@@ -9,20 +9,31 @@ Python implementation of the `Socket.IO`_ realtime server.
 Features
 --------
 
--  Fully compatible with the Javascript `socket.io-client`_ library.
--  Compatible with Python 2.7 and Python 3.3+.
--  Based on `Eventlet`_, enabling large number of clients even on modest
-   hardware.
--  Includes a WSGI middleware that integrates Socket.IO traffic with
-   standard WSGI applications.
--  Uses an event-based architecture implemented with decorators that
-   hides the details of the protocol.
--  Implements HTTP long-polling and WebSocket transports.
--  Supports XHR2 and XHR browsers as clients.
--  Supports text and binary messages.
--  Supports gzip and deflate HTTP compression.
--  Configurable CORS responses to avoid cross-origin problems with
-   browsers.
+- Fully compatible with the 
+  `Javascript <https://github.com/Automattic/socket.io-client>`_,
+  `Swift <https://github.com/socketio/socket.io-client-swift>`_,
+  `C++ <https://github.com/socketio/socket.io-client-cpp>`_ and
+  `Java <https://github.com/socketio/socket.io-client-java>`_ official
+  Socket.IO clients, plus any third party clients that comply with the
+  Socket.IO specification.
+- Compatible with Python 2.7 and Python 3.3+.
+- Supports large number of clients even on modest hardware when used with an
+  asynchronous server based on `eventlet <http://eventlet.net/>`_ or
+  `gevent <http://gevent.org/>`_. For development and testing, any WSGI
+  complaint multi-threaded server can be used.
+- Includes a WSGI middleware that integrates Socket.IO traffic with standard
+  WSGI applications.
+- Broadcasting of messages to all connected clients, or to subsets of them
+  assigned to "rooms".
+- Optional support for multiple servers, connected through a messaging queue
+  such as Redis or RabbitMQ.
+- Event-based architecture implemented with decorators that hides the details
+  of the protocol.
+- Support for HTTP long-polling and WebSocket transports.
+- Support for XHR2 and XHR browsers.
+- Support for text and binary messages.
+- Support for gzip and deflate HTTP compression.
+- Configurable CORS responses, to avoid cross-origin problems with browsers.
 
 Example
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,8 @@ features:
   assigned to "rooms".
 - Optional support for multiple servers, connected through a messaging queue
   such as Redis or RabbitMQ.
+- Send messages to clients from external processes, such as Celery workers or
+  auxiliary scripts.
 - Event-based architecture implemented with decorators that hides the details
   of the protocol.
 - Support for HTTP long-polling and WebSocket transports.
@@ -212,13 +214,14 @@ Using a Message Queue
 ---------------------
 
 The Socket.IO server owns the socket connections to all the clients, so it is
-the only process that can emit events to them. A common need of larger
-applications is to emit events to clients from a different process, like a
-a `Celery <http://www.celeryproject.org/>`_ worker, or any other auxiliary
-process that works in conjunction with the server.
+the only process that can emit events to them. Unfortunately this becomes a
+limitation for many applications, as a common need is to emit events to
+clients from a different process, like a
+`Celery <http://www.celeryproject.org/>`_ worker, or any other auxiliary
+process or script that works in conjunction with the server.
 
 To enable these other processes to emit events, the server can be configured
-to listen for events to emit to clients on a message queue such as
+to listen for externally issued events on a message queue such as
 `Redis <http://redis.io/>`_ or `RabbitMQ <https://www.rabbitmq.com/>`_.
 Processes that need to emit events to client then post these events to the
 queue.
@@ -232,7 +235,7 @@ ta message queue.
 
 The message queue service needs to be installed and configured separately. By
 default, the server uses `Kombu <http://kombu.readthedocs.org/en/latest/>`_
-to read and write to the queue, so any message queue supported by this package
+to access the message queue, so any message queue supported by this package
 can be used. Kombu can be installed with pip::
 
     pip install kombu

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,13 @@ This project implements an Socket.IO server that can run standalone or
 integrated with a Python WSGI application. The following are some of its
 features:
 
-- Fully compatible with the Javascript
-  `socket.io-client <https://github.com/Automattic/socket.io-client>`_ library,
-  versions 1.3.5 and up.
+- Fully compatible with the 
+  `Javascript <https://github.com/Automattic/socket.io-client>`_,
+  `Swift <https://github.com/socketio/socket.io-client-swift>`_,
+  `C++ <https://github.com/socketio/socket.io-client-cpp>`_ and
+  `Java <https://github.com/socketio/socket.io-client-java>`_ official
+  Socket.IO clients, plus any third party clients that comply with the
+  Socket.IO specification.
 - Compatible with Python 2.7 and Python 3.3+.
 - Supports large number of clients even on modest hardware when used with an
   asynchronous server based on `eventlet <http://eventlet.net/>`_ or
@@ -24,20 +28,22 @@ features:
   WSGI applications.
 - Broadcasting of messages to all connected clients, or to subsets of them
   assigned to "rooms".
-- Uses an event-based architecture implemented with decorators that hides the
-  details of the protocol.
+- Optional support for multiple servers, connected through a messaging queue
+  such as Redis or RabbitMQ.
+- Event-based architecture implemented with decorators that hides the details
+  of the protocol.
 - Support for HTTP long-polling and WebSocket transports.
 - Support for XHR2 and XHR browsers.
 - Support for text and binary messages.
 - Support for gzip and deflate HTTP compression.
-- Configurable CORS responses to avoid cross-origin problems with browsers.
+- Configurable CORS responses, to avoid cross-origin problems with browsers.
 
 What is Socket.IO?
 ------------------
 
 Socket.IO is a transport protocol that enables real-time bidirectional
 event-based communication between clients (typically web browsers) and a
-server. The official implementations of the client and server components are
+server. The original implementations of the client and server components are
 written in JavaScript.
 
 Getting Started
@@ -357,13 +363,16 @@ address this important limitation.
 API Reference
 -------------
 
-.. toctree::
-   :maxdepth: 2
-
 .. module:: socketio
-
 .. autoclass:: Middleware
    :members:
-
 .. autoclass:: Server
+   :members:
+.. autoclass:: BaseManager
+   :members:
+.. autoclass:: PubSubManager
+   :members:
+.. autoclass:: KombuManager
+   :members:
+.. autoclass:: RedisManager
    :members:

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -1,4 +1,9 @@
 from .middleware import Middleware
+from .base_manager import BaseManager
+from .pubsub_manager import PubSubManager
+from .kombu_manager import KombuManager
+from .redis_manager import RedisManager
 from .server import Server
 
-__all__ = [Middleware, Server]
+__all__ = [Middleware, Server, BaseManager, PubSubManager, KombuManager,
+           RedisManager]

--- a/socketio/base_manager.py
+++ b/socketio/base_manager.py
@@ -104,12 +104,16 @@ class BaseManager(object):
 
     def trigger_callback(self, sid, namespace, id, data):
         """Invoke an application callback."""
+        callback = None
         try:
             callback = self.callbacks[sid][namespace][id]
         except KeyError:
-            raise ValueError('Unknown callback')
-        del self.callbacks[sid][namespace][id]
-        callback(*data)
+            # if we get an unknown callback we just ignore it
+            self.server.logger.warning('Unknown callback received, ignoring.')
+        else:
+            del self.callbacks[sid][namespace][id]
+        if callback is not None:
+            callback(*data)
 
     def _generate_ack_id(self, sid, namespace, callback):
         """Generate a unique identifier for an ACK packet."""

--- a/socketio/base_manager.py
+++ b/socketio/base_manager.py
@@ -12,11 +12,14 @@ class BaseManager(object):
     services. More sophisticated storage backends can be implemented by
     subclasses.
     """
-    def __init__(self, server):
-        self.server = server
+    def __init__(self):
+        self.server = None
         self.rooms = {}
         self.pending_removals = []
         self.callbacks = {}
+
+    def initialize(self, server):
+        self.server = server
 
     def get_namespaces(self):
         """Return an iterable with the active namespace names."""
@@ -69,7 +72,7 @@ class BaseManager(object):
         except KeyError:
             pass
 
-    def close_room(self, namespace, room):
+    def close_room(self, room, namespace):
         """Remove all participants from a room."""
         try:
             for sid in self.get_participants(namespace, room):

--- a/socketio/kombu_manager.py
+++ b/socketio/kombu_manager.py
@@ -1,0 +1,64 @@
+import json
+import pickle
+
+import six
+try:
+    import kombu
+except ImportError:
+    kombu = None
+
+from .pubsub_manager import PubSubManager
+
+
+class KombuManager(PubSubManager):
+    """Client manager that uses kombu for inter-process messaging.
+
+    This class implements a client manager backend for event sharing across
+    multiple processes, using RabbitMQ, Redis or any other messaging mechanism
+    supported by `kombu <http://kombu.readthedocs.org/en/latest/>`_.
+
+    To use a kombu backend, initialize the :class:`Server` instance as
+    follows::
+
+        url = 'amqp://user:password@hostname:port//'
+        server = socketio.Server(client_manager=socketio.KombuManager(url))
+
+    :param url: The connection URL for the backend messaging queue. Example
+                connection URLs are ``'amqp://guest:guest@localhost:5672//'``
+                and ``'redis://localhost:6379/'`` for RabbitMQ and Redis
+                respectively. Consult the `kombu documentation
+                <http://kombu.readthedocs.org/en/latest/userguide\
+                /connections.html#urls>`_ for more on how to construct
+                connection URLs.
+    :param channel: The channel name on which the server sends and receives
+                    notifications. Must be the same in all the servers.
+    """
+    name = 'kombu'
+
+    def __init__(self, url='amqp://guest:guest@localhost:5672//',
+                 channel='socketio'):
+        if kombu is None:
+            raise RuntimeError('Kombu package is not installed '
+                               '(Run "pip install kombu" in your '
+                               'virtualenv).')
+        self.kombu = kombu.Connection(url)
+        self.queue = self.kombu.SimpleQueue(channel)
+        super(KombuManager, self).__init__(channel=channel)
+
+    def _publish(self, data):
+        return self.queue.put(pickle.dumps(data))
+
+    def _listen(self):
+        listen_queue = self.kombu.SimpleQueue(self.channel)
+        while True:
+            message = listen_queue.get(block=True)
+            message.ack()
+            data = None
+            if isinstance(message.payload, six.binary_type):
+                try:
+                    data = pickle.loads(message.payload)
+                except pickle.PickleError:
+                    pass
+            if data is None:
+                data = json.loads(message.payload)
+            yield data

--- a/socketio/kombu_manager.py
+++ b/socketio/kombu_manager.py
@@ -57,8 +57,12 @@ class KombuManager(PubSubManager):
             if isinstance(message.payload, six.binary_type):
                 try:
                     data = pickle.loads(message.payload)
-                except pickle.PickleError:
+                except:
                     pass
             if data is None:
-                data = json.loads(message.payload)
-            yield data
+                try:
+                    data = json.loads(message.payload)
+                except:
+                    pass
+            if data:
+                yield data

--- a/socketio/kombu_manager.py
+++ b/socketio/kombu_manager.py
@@ -1,7 +1,5 @@
-import json
 import pickle
 
-import six
 try:
     import kombu
 except ImportError:
@@ -10,7 +8,7 @@ except ImportError:
 from .pubsub_manager import PubSubManager
 
 
-class KombuManager(PubSubManager):
+class KombuManager(PubSubManager):  # pragma: no cover
     """Client manager that uses kombu for inter-process messaging.
 
     This class implements a client manager backend for event sharing across
@@ -53,16 +51,4 @@ class KombuManager(PubSubManager):
         while True:
             message = listen_queue.get(block=True)
             message.ack()
-            data = None
-            if isinstance(message.payload, six.binary_type):
-                try:
-                    data = pickle.loads(message.payload)
-                except:
-                    pass
-            if data is None:
-                try:
-                    data = json.loads(message.payload)
-                except:
-                    pass
-            if data:
-                yield data
+            yield message.payload

--- a/socketio/pubsub_manager.py
+++ b/socketio/pubsub_manager.py
@@ -1,0 +1,77 @@
+from .base_manager import BaseManager
+
+
+class PubSubManager(BaseManager):
+    """Manage a client list attached to a pub/sub backend.
+
+    This is a base class that enables multiple servers to share the list of
+    clients, with the servers communicating events through a pub/sub backend.
+    The use of a pub/sub backend also allows any client connected to the
+    backend to emit events addressed to Socket.IO clients.
+
+    The actual backends must be implemented by subclasses, this class only
+    provides a pub/sub generic framework.
+
+    :param channel: The channel name on which the server sends and receives
+                    notifications.
+    """
+    def __init__(self, channel='socketio'):
+        super(PubSubManager, self).__init__()
+        self.channel = channel
+
+    def initialize(self, server):
+        super(PubSubManager, self).initialize(server)
+        self.thread = self.server.start_background_task(self._thread)
+        self.server.logger.info(self.name + ' backend initialized.')
+
+    def emit(self, event, data, namespace=None, room=None, skip_sid=None,
+             callback=None):
+        """Emit a message to a single client, a room, or all the clients
+        connected to the namespace.
+
+        This method takes care or propagating the message to all the servers
+        that are connected through the message queue.
+
+        The parameters are the same as in :meth:`.Server.emit`.
+        """
+        self._publish({'method': 'emit', 'event': event, 'data': data,
+                       'namespace': namespace or '/', 'room': room,
+                       'skip_sid': skip_sid, 'callback': callback})
+
+    def close_room(self, room, namespace=None):
+        self._publish({'method': 'close_room', 'room': room,
+                       'namespace': namespace or '/'})
+
+    def _publish(self, data):
+        """Publish a message on the Socket.IO channel.
+
+        This method needs to be implemented by the different subclasses that
+        support pub/sub backends.
+        """
+        raise NotImplementedError('This method must be implemented in a '
+                                  'subclass.')
+
+    def _listen(self):
+        """Return the next message published on the Socket.IO channel,
+        blocking until a message is available.
+
+        This method needs to be implemented by the different subclasses that
+        support pub/sub backends.
+        """
+        raise NotImplementedError('This method must be implemented in a '
+                                  'subclass.')
+
+    def _thread(self):
+        for message in self._listen():
+            if 'method' in message:
+                if message['method'] == 'emit':
+                    super(PubSubManager, self).emit(
+                        message['event'], message['data'],
+                        namespace=message.get('namespace'),
+                        room=message.get('room'),
+                        skip_sid=message.get('skip_sid'),
+                        callback=message.get('callback'))
+                elif message['method'] == 'close_room':
+                    super(PubSubManager, self).close_room(
+                        room=message.get('room'),
+                        namespace=message.get('namespace'))

--- a/socketio/pubsub_manager.py
+++ b/socketio/pubsub_manager.py
@@ -46,6 +46,9 @@ class PubSubManager(BaseManager):
         """
         namespace = namespace or '/'
         if callback is not None:
+            if self.server is None:
+                raise RuntimeError('Callbacks can only be issued from the '
+                                   'context of a server.')
             if room is None:
                 raise ValueError('Cannot use callback without a room set.')
             id = self._generate_ack_id(room, namespace, callback)

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -1,7 +1,5 @@
-import json
 import pickle
 
-import six
 try:
     import redis
 except ImportError:
@@ -10,7 +8,7 @@ except ImportError:
 from .pubsub_manager import PubSubManager
 
 
-class RedisManager(PubSubManager):
+class RedisManager(PubSubManager):  # pragma: no cover
     """Redis based client manager.
 
     This class implements a Redis backend for event sharing across multiple
@@ -48,17 +46,5 @@ class RedisManager(PubSubManager):
         for message in self.pubsub.listen():
             if message['channel'] == channel and \
                     message['type'] == 'message' and 'data' in message:
-                data = None
-                if isinstance(message['data'], six.binary_type):
-                    try:
-                        data = pickle.loads(message['data'])
-                    except:
-                        pass
-                if data is None:
-                    try:
-                        data = json.loads(message['data'])
-                    except:
-                        pass
-                if data:
-                    yield data
+                yield message['data']
         self.pubsub.unsubscribe(self.channel)

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -1,0 +1,60 @@
+import json
+import pickle
+
+import six
+try:
+    import redis
+except ImportError:
+    redis = None
+
+from .pubsub_manager import PubSubManager
+
+
+class RedisManager(PubSubManager):
+    """Redis based client manager.
+
+    This class implements a Redis backend for event sharing across multiple
+    processes. Only kept here as one more example of how to build a custom
+    backend, since the kombu backend is perfectly adequate to support a Redis
+    message queue.
+
+    To use a Redis backend, initialize the :class:`Server` instance as
+    follows::
+
+        url = 'redis://hostname:port/0'
+        server = socketio.Server(client_manager=socketio.RedisManager(url))
+
+    :param url: The connection URL for the Redis server.
+    :param channel: The channel name on which the server sends and receives
+                    notifications. Must be the same in all the servers.
+    """
+    name = 'redis'
+
+    def __init__(self, url='redis://localhost:6379/0', channel='socketio'):
+        if redis is None:
+            raise RuntimeError('Redis package is not installed '
+                               '(Run "pip install redis" in your '
+                               'virtualenv).')
+        self.redis = redis.Redis.from_url(url)
+        self.pubsub = self.redis.pubsub()
+        super(RedisManager, self).__init__(channel=channel)
+
+    def _publish(self, data):
+        return self.redis.publish(self.channel, pickle.dumps(data))
+
+    def _listen(self):
+        channel = self.channel.encode('utf-8')
+        self.pubsub.subscribe(self.channel)
+        for message in self.pubsub.listen():
+            if message['channel'] == channel and \
+                    message['type'] == 'message' and 'data' in message:
+                data = None
+                if isinstance(message['data'], six.binary_type):
+                    try:
+                        data = pickle.loads(message['data'])
+                    except pickle.PickleError:
+                        pass
+                if data is None:
+                    data = json.loads(message['data'])
+                yield data
+        self.pubsub.unsubscribe(self.channel)

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -52,9 +52,13 @@ class RedisManager(PubSubManager):
                 if isinstance(message['data'], six.binary_type):
                     try:
                         data = pickle.loads(message['data'])
-                    except pickle.PickleError:
+                    except:
                         pass
                 if data is None:
-                    data = json.loads(message['data'])
-                yield data
+                    try:
+                        data = json.loads(message['data'])
+                    except:
+                        pass
+                if data:
+                    yield data
         self.pubsub.unsubscribe(self.channel)

--- a/tests/test_base_manager.py
+++ b/tests/test_base_manager.py
@@ -12,7 +12,8 @@ from socketio import base_manager
 class TestBaseManager(unittest.TestCase):
     def setUp(self):
         mock_server = mock.MagicMock()
-        self.bm = base_manager.BaseManager(mock_server)
+        self.bm = base_manager.BaseManager()
+        self.bm.initialize(mock_server)
 
     def test_connect(self):
         self.bm.connect('123', '/foo')
@@ -142,11 +143,11 @@ class TestBaseManager(unittest.TestCase):
         self.bm.connect('789', '/foo')
         self.bm.enter_room('123', '/foo', 'bar')
         self.bm.enter_room('123', '/foo', 'bar')
-        self.bm.close_room('/foo', 'bar')
+        self.bm.close_room('bar', '/foo')
         self.assertNotIn('bar', self.bm.rooms['/foo'])
 
     def test_close_invalid_room(self):
-        self.bm.close_room('/foo', 'bar')
+        self.bm.close_room('bar', '/foo')
 
     def test_rooms(self):
         self.bm.connect('123', '/foo')

--- a/tests/test_base_manager.py
+++ b/tests/test_base_manager.py
@@ -104,12 +104,11 @@ class TestBaseManager(unittest.TestCase):
         self.bm.connect('123', '/')
         cb = mock.MagicMock()
         id = self.bm._generate_ack_id('123', '/', cb)
-        self.assertRaises(ValueError, self.bm.trigger_callback,
-                          '124', '/', id, ['foo'])
-        self.assertRaises(ValueError, self.bm.trigger_callback,
-                          '123', '/foo', id, ['foo'])
-        self.assertRaises(ValueError, self.bm.trigger_callback,
-                          '123', '/', id + 1, ['foo'])
+
+        # these should not raise an exception
+        self.bm.trigger_callback('124', '/', id, ['foo'])
+        self.bm.trigger_callback('123', '/foo', id, ['foo'])
+        self.bm.trigger_callback('123', '/', id + 1, ['foo'])
         self.assertEqual(cb.call_count, 0)
 
     def test_get_namespaces(self):

--- a/tests/test_pubsub_manager.py
+++ b/tests/test_pubsub_manager.py
@@ -66,6 +66,11 @@ class TestBaseManager(unittest.TestCase):
                  'namespace': '/', 'room': 'baz', 'skip_sid': None,
                  'callback': ('baz', '/', '123')})
 
+    def test_emit_with_callback_without_server(self):
+        standalone_pm = pubsub_manager.PubSubManager()
+        self.assertRaises(RuntimeError, standalone_pm.emit, 'foo', 'bar',
+                          callback='cb')
+
     def test_emit_with_callback_missing_room(self):
         with mock.patch.object(self.pm, '_generate_ack_id',
                                return_value='123'):

--- a/tests/test_pubsub_manager.py
+++ b/tests/test_pubsub_manager.py
@@ -1,0 +1,209 @@
+import functools
+import unittest
+
+import six
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
+
+from socketio import base_manager
+from socketio import pubsub_manager
+
+
+class TestBaseManager(unittest.TestCase):
+    def setUp(self):
+        mock_server = mock.MagicMock()
+        self.pm = pubsub_manager.PubSubManager()
+        self.pm._publish = mock.MagicMock()
+        self.pm.initialize(mock_server)
+
+    def test_default_init(self):
+        self.assertEqual(self.pm.channel, 'socketio')
+        self.assertEqual(len(self.pm.host_id), 32)
+        self.pm.server.start_background_task.assert_called_once_with(
+            self.pm._thread)
+
+    def test_custom_init(self):
+        pubsub = pubsub_manager.PubSubManager(channel='foo')
+        self.assertEqual(pubsub.channel, 'foo')
+        self.assertEqual(len(pubsub.host_id), 32)
+
+    def test_emit(self):
+        self.pm.emit('foo', 'bar')
+        self.pm._publish.assert_called_once_with(
+            {'method': 'emit', 'event': 'foo', 'data': 'bar',
+             'namespace': '/', 'room': None, 'skip_sid': None,
+             'callback': None})
+
+    def test_emit_with_namespace(self):
+        self.pm.emit('foo', 'bar', namespace='/baz')
+        self.pm._publish.assert_called_once_with(
+            {'method': 'emit', 'event': 'foo', 'data': 'bar',
+             'namespace': '/baz', 'room': None, 'skip_sid': None,
+             'callback': None})
+
+    def test_emit_with_room(self):
+        self.pm.emit('foo', 'bar', room='baz')
+        self.pm._publish.assert_called_once_with(
+            {'method': 'emit', 'event': 'foo', 'data': 'bar',
+             'namespace': '/', 'room': 'baz', 'skip_sid': None,
+             'callback': None})
+
+    def test_emit_with_skip_sid(self):
+        self.pm.emit('foo', 'bar', skip_sid='baz')
+        self.pm._publish.assert_called_once_with(
+            {'method': 'emit', 'event': 'foo', 'data': 'bar',
+             'namespace': '/', 'room': None, 'skip_sid': 'baz',
+             'callback': None})
+
+    def test_emit_with_callback(self):
+        with mock.patch.object(self.pm, '_generate_ack_id',
+                               return_value='123'):
+            self.pm.emit('foo', 'bar', room='baz', callback='cb')
+            self.pm._publish.assert_called_once_with(
+                {'method': 'emit', 'event': 'foo', 'data': 'bar',
+                 'namespace': '/', 'room': 'baz', 'skip_sid': None,
+                 'callback': ('baz', '/', '123')})
+
+    def test_emit_with_callback_missing_room(self):
+        with mock.patch.object(self.pm, '_generate_ack_id',
+                               return_value='123'):
+            self.assertRaises(ValueError, self.pm.emit, 'foo', 'bar',
+                              callback='cb')
+
+    def test_close_room(self):
+        self.pm.close_room('foo')
+        self.pm._publish.assert_called_once_with(
+            {'method': 'close_room', 'room': 'foo', 'namespace': '/'})
+
+    def test_close_room_with_namespace(self):
+        self.pm.close_room('foo', '/bar')
+        self.pm._publish.assert_called_once_with(
+            {'method': 'close_room', 'room': 'foo', 'namespace': '/bar'})
+
+    def test_handle_emit(self):
+        with mock.patch.object(base_manager.BaseManager, 'emit') as super_emit:
+            self.pm._handle_emit({'event': 'foo', 'data': 'bar'})
+            super_emit.assert_called_once_with('foo', 'bar', namespace=None,
+                                               room=None, skip_sid=None,
+                                               callback=None)
+
+    def test_handle_emit_with_namespace(self):
+        with mock.patch.object(base_manager.BaseManager, 'emit') as super_emit:
+            self.pm._handle_emit({'event': 'foo', 'data': 'bar',
+                                  'namespace': '/baz'})
+            super_emit.assert_called_once_with('foo', 'bar', namespace='/baz',
+                                               room=None, skip_sid=None,
+                                               callback=None)
+
+    def test_handle_emiti_with_room(self):
+        with mock.patch.object(base_manager.BaseManager, 'emit') as super_emit:
+            self.pm._handle_emit({'event': 'foo', 'data': 'bar',
+                                  'room': 'baz'})
+            super_emit.assert_called_once_with('foo', 'bar', namespace=None,
+                                               room='baz', skip_sid=None,
+                                               callback=None)
+
+    def test_handle_emit_with_skip_sid(self):
+        with mock.patch.object(base_manager.BaseManager, 'emit') as super_emit:
+            self.pm._handle_emit({'event': 'foo', 'data': 'bar',
+                                  'skip_sid': '123'})
+            super_emit.assert_called_once_with('foo', 'bar', namespace=None,
+                                               room=None, skip_sid='123',
+                                               callback=None)
+
+    def test_handle_emit_with_callback(self):
+        host_id = self.pm.host_id
+        with mock.patch.object(base_manager.BaseManager, 'emit') as super_emit:
+            self.pm._handle_emit({'event': 'foo', 'data': 'bar',
+                                  'namespace': '/baz',
+                                  'callback': ('sid', '/baz', 123)})
+            self.assertEqual(super_emit.call_count, 1)
+            self.assertEqual(super_emit.call_args[0], ('foo', 'bar'))
+            self.assertEqual(super_emit.call_args[1]['namespace'], '/baz')
+            self.assertIsNone(super_emit.call_args[1]['room'])
+            self.assertIsNone(super_emit.call_args[1]['skip_sid'])
+            self.assertIsInstance(super_emit.call_args[1]['callback'],
+                                  functools.partial)
+            super_emit.call_args[1]['callback']('one', 2, 'three')
+            self.pm._publish.assert_called_once_with(
+                {'method': 'callback', 'host_id': host_id, 'sid': 'sid',
+                 'namespace': '/baz', 'id': 123, 'args': ('one', 2, 'three')})
+
+    def test_handle_callback(self):
+        host_id = self.pm.host_id
+        with mock.patch.object(self.pm, 'trigger_callback') as trigger:
+            self.pm._handle_callback({'method': 'callback',
+                                      'host_id': host_id, 'sid': 'sid',
+                                      'namespace': '/', 'id': 123,
+                                      'args': ('one', 2)})
+            trigger.assert_called_once_with('sid', '/', 123, ('one', 2))
+
+    def test_handle_callback_bad_host_id(self):
+        with mock.patch.object(self.pm, 'trigger_callback') as trigger:
+            self.pm._handle_callback({'method': 'callback',
+                                      'host_id': 'bad', 'sid': 'sid',
+                                      'namespace': '/', 'id': 123,
+                                      'args': ('one', 2)})
+            self.assertEqual(trigger.call_count, 0)
+
+    def test_handle_callback_missing_args(self):
+        host_id = self.pm.host_id
+        with mock.patch.object(self.pm, 'trigger_callback') as trigger:
+            self.pm._handle_callback({'method': 'callback',
+                                      'host_id': host_id, 'sid': 'sid',
+                                      'namespace': '/', 'id': 123})
+            self.pm._handle_callback({'method': 'callback',
+                                      'host_id': host_id, 'sid': 'sid',
+                                      'namespace': '/'})
+            self.pm._handle_callback({'method': 'callback',
+                                      'host_id': host_id, 'sid': 'sid'})
+            self.pm._handle_callback({'method': 'callback',
+                                      'host_id': host_id})
+            self.assertEqual(trigger.call_count, 0)
+
+    def test_handle_close_room(self):
+        with mock.patch.object(base_manager.BaseManager, 'close_room') \
+                as super_close_room:
+            self.pm._handle_close_room({'method': 'close_room',
+                                        'room': 'foo'})
+            super_close_room.assert_called_once_with(room='foo',
+                                                     namespace=None)
+
+    def test_handle_close_room_with_namespace(self):
+        with mock.patch.object(base_manager.BaseManager, 'close_room') \
+                as super_close_room:
+            self.pm._handle_close_room({'method': 'close_room',
+                                        'room': 'foo', 'namespace': '/bar'})
+            super_close_room.assert_called_once_with(room='foo',
+                                                     namespace='/bar')
+
+    def test_background_thread(self):
+        self.pm._handle_emit = mock.MagicMock()
+        self.pm._handle_callback = mock.MagicMock()
+        self.pm._handle_close_room = mock.MagicMock()
+
+        def messages():
+            import pickle
+            yield {'method': 'emit', 'value': 'foo'}
+            yield {'missing': 'method'}
+            yield '{"method": "callback", "value": "bar"}'
+            yield {'method': 'bogus'}
+            yield pickle.dumps({'method': 'close_room', 'value': 'baz'})
+            yield 'bad json'
+            yield b'bad pickled'
+            raise KeyboardInterrupt
+
+        self.pm._listen = mock.MagicMock(side_effect=messages)
+        try:
+            self.pm._thread()
+        except KeyboardInterrupt:
+            pass
+
+        self.pm._handle_emit.assert_called_once_with(
+            {'method': 'emit', 'value': 'foo'})
+        self.pm._handle_callback.assert_called_once_with(
+            {'method': 'callback', 'value': 'bar'})
+        self.pm._handle_close_room.assert_called_once_with(
+            {'method': 'close_room', 'value': 'baz'})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,13 +92,13 @@ class TestServer(unittest.TestCase):
         mgr = mock.MagicMock()
         s = server.Server(client_manager=mgr)
         s.close_room('room', namespace='/foo')
-        s.manager.close_room.assert_called_once_with('/foo', 'room')
+        s.manager.close_room.assert_called_once_with('room', '/foo')
 
     def test_close_room_default_namespace(self, eio):
         mgr = mock.MagicMock()
         s = server.Server(client_manager=mgr)
         s.close_room('room')
-        s.manager.close_room.assert_called_once_with('/', 'room')
+        s.manager.close_room.assert_called_once_with('room', '/')
 
     def test_rooms(self, eio):
         mgr = mock.MagicMock()
@@ -397,3 +397,9 @@ class TestServer(unittest.TestCase):
 
         # restore the default JSON module
         packet.Packet.json = json
+
+    def test_start_background_task(self, eio):
+        s = server.Server()
+        s.start_background_task('foo', 'bar', baz='baz')
+        s.eio.start_background_task.assert_called_once_with('foo', 'bar',
+                                                            baz='baz')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -274,7 +274,9 @@ class TestServer(unittest.TestCase):
         s._handle_eio_message('123', '61-1["my message","a",'
                                      '{"_placeholder":true,"num":0}]')
         self.assertEqual(s._attachment_count, 1)
-        self.assertRaises(ValueError, s._handle_eio_message, '123', b'foo')
+        # the following call should not raise an exception in spite of the
+        # callback id being invalid
+        s._handle_eio_message('123', b'foo')
 
     def test_handle_event_with_ack(self, eio):
         s = server.Server()


### PR DESCRIPTION
This change adds optional support for a message queue (via Kombu) that can be used for two purposes:

1. Multiple Socket.IO worker processes can share the list of clients. When broadcasting messages to all users or to rooms, the servers coordinate what clients need to be addressed by passing messages through the queue.

2. External processes such as Celery workers or auxiliary scripts can emit events to clients just by posting them to the message queue.