### PR TITLE
Avoid KeyError when no room exists

### DIFF
--- a/socketio/base_manager.py
+++ b/socketio/base_manager.py
@@ -83,9 +83,12 @@ class BaseManager(object):
     def get_rooms(self, sid, namespace):
         """Return the rooms a client is in."""
         r = []
-        for room_name, room in six.iteritems(self.rooms[namespace]):
-            if room_name is not None and sid in room and room[sid]:
-                r.append(room_name)
+        try:
+            for room_name, room in six.iteritems(self.rooms[namespace]):
+                if room_name is not None and sid in room and room[sid]:
+                    r.append(room_name)
+        except KeyError:
+            pass
         return r
 
     def emit(self, event, data, namespace, room=None, skip_sid=None,

--- a/tests/test_base_manager.py
+++ b/tests/test_base_manager.py
@@ -131,6 +131,10 @@ class TestBaseManager(unittest.TestCase):
         self.bm.leave_room('123', '/foo', 'baz')
         self.bm.leave_room('123', '/bar', 'baz')
 
+    def test_no_room(self):
+        rooms = self.bm.get_rooms('123', '/foo')
+        self.assertEqual([], rooms)
+
     def test_close_room(self):
         self.bm.connect('123', '/foo')
         self.bm.connect('456', '/foo')


### PR DESCRIPTION
Without this modification, base_manager.get_rooms() fails with a KeyError when no room exists:

```
ERROR: test_no_room (tests.test_base_manager.TestBaseManager)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pdecat/workspaces/thirdparty/python-socketio/tests/test_base_manager.py", line 135, in test_no_room
    rooms = self.bm.get_rooms('123', '/foo')
  File "/home/pdecat/workspaces/thirdparty/python-socketio/socketio/base_manager.py", line 86, in get_rooms
    for room_name, room in six.iteritems(self.rooms[namespace]):
KeyError: '/foo'
```