### PR TITLE
Add wildcard event

### DIFF
--- a/socketio/server.py
+++ b/socketio/server.py
@@ -397,6 +397,7 @@ class Server(object):
         namespace = namespace or '/'
         self.logger.info('received event "%s" from %s [%s]', data[0], sid,
                          namespace)
+        self._trigger_event('*', namespace, sid, *data)
         r = self._trigger_event(data[0], namespace, sid, *data[1:])
         if id is not None:
             # send ACK packet with the response returned by the handler

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -269,6 +269,13 @@ class TestServer(unittest.TestCase):
         s._handle_eio_message('123', '2["my message","a","b","c"]')
         handler.assert_called_once_with('123', 'a', 'b', 'c')
 
+    def test_handle_event_wildcard(self, eio):
+        s = server.Server()
+        handler = mock.MagicMock()
+        s.on('*', handler)
+        s._handle_eio_message('123', '2["my message","a","b","c"]')
+        handler.assert_called_once_with('123', 'my message', 'a', 'b', 'c')
+
     def test_handle_event_with_namespace(self, eio):
         s = server.Server()
         handler = mock.MagicMock()


### PR DESCRIPTION
So I found myself in need to capture any incoming event. This patch introduces the wildcard (notice no plural form) event, which is basically triggered for every message coming from the client.

The API is pretty similar except the event name is passed as the first argument:

``` python
@sio.on('*')
def catch_em_all(event, *data):
    ...
```
