### PR TITLE
Event handler interceptors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ client:
 
     import socketio
     import eventlet
+    import eventlet.wsgi
     from flask import Flask, render_template
 
     sio = socketio.Server()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -213,6 +213,37 @@ methods in the :class:`socketio.Server` class.
 When the ``namespace`` argument is omitted, set to ``None`` or to ``'/'``, the
 default namespace, representing the physical connection, is used.
 
+Class-Based Namespaces
+----------------------
+
+As an alternative to the decorator-based event handlers, the event handlers
+that belong to a namespace can be created as methods of a subclass of 
+:class:`socketio.Namespace`::
+
+    class MyCustomNamespace(socketio.Namespace):
+        def on_connect(sid, environ):
+            pass
+
+        def on_disconnect(sid):
+            pass
+
+        def on_my_event(sid, data):
+            self.emit('my_response', data)
+
+    sio.register_namespace(MyCustomNamespace('/test'))
+
+When class-based namespaces are used, any events received by the server are
+dispatched to a method named as the event name with the ``on_`` prefix. For
+example, event ``my_event`` will be handled by a method named ``on_my_event``.
+If an event is received for which there is no corresponding method defined in
+the namespace class, then the event is ignored. All event names used in
+class-based namespaces must used characters that are legal in method names.
+
+As a convenience to methods defined in a class-based namespace, the namespace
+instance includes versions of several of the methods in the 
+:class:`socketio.Server` class that default to the proper namespace when the
+``namespace`` argument is not given.
+
 Using a Message Queue
 ---------------------
 
@@ -456,6 +487,8 @@ API Reference
 .. autoclass:: Middleware
    :members:
 .. autoclass:: Server
+   :members:
+.. autoclass:: Namespace
    :members:
 .. autoclass:: BaseManager
    :members:

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -4,6 +4,7 @@ from .pubsub_manager import PubSubManager
 from .kombu_manager import KombuManager
 from .redis_manager import RedisManager
 from .server import Server
+from .namespace import Namespace
 
 __all__ = [Middleware, Server, BaseManager, PubSubManager, KombuManager,
-           RedisManager]
+           RedisManager, Namespace]

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -6,7 +6,8 @@ from .pubsub_manager import PubSubManager
 from .kombu_manager import KombuManager
 from .redis_manager import RedisManager
 from .server import Server
-from .util import apply_interceptor
+from .util import apply_interceptor, ignore_interceptor
 
 __all__ = [Interceptor, Middleware, Namespace, Server, BaseManager,
-           PubSubManager, KombuManager, RedisManager, apply_interceptor]
+           PubSubManager, KombuManager, RedisManager,
+           apply_interceptor, ignore_interceptor]

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -1,11 +1,12 @@
 from .middleware import Middleware
+from .interceptor import Interceptor
 from .namespace import Namespace
 from .base_manager import BaseManager
 from .pubsub_manager import PubSubManager
 from .kombu_manager import KombuManager
 from .redis_manager import RedisManager
 from .server import Server
-from .util import apply_middleware
+from .util import apply_interceptor
 
-__all__ = [Middleware, Namespace, Server, BaseManager, PubSubManager,
-           KombuManager, RedisManager, apply_middleware]
+__all__ = [Interceptor, Middleware, Namespace, Server, BaseManager,
+           PubSubManager, KombuManager, RedisManager, apply_interceptor]

--- a/socketio/interceptor.py
+++ b/socketio/interceptor.py
@@ -1,0 +1,17 @@
+class Interceptor(object):
+    """Base class for event handler interceptors."""
+
+    def __init__(self, server):
+        self.server = server
+
+    def ignore_for(self, event, namespace):
+        return False
+
+    def before_event(self, event, namespace, args):
+        pass
+
+    def after_event(self, event, namespace, args):
+        pass
+
+    def handle_exception(self, event, namespace, exc):
+        raise exc

--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -1,0 +1,96 @@
+class Namespace(object):
+    """Base class for class-based namespaces.
+
+    A class-based namespace is a class that contains all the event handlers
+    for a Socket.IO namespace. The event handlers are methods of the class
+    with the prefix ``on_``, such as ``on_connect``, ``on_disconnect``,
+    ``on_message``, ``on_json``, and so on.
+
+    :param namespace: The Socket.IO namespace to be used with all the event
+                      handlers defined in this class. If this argument is
+                      omitted, the default namespace is used.
+    """
+    def __init__(self, namespace=None):
+        self.namespace = namespace or '/'
+        self.server = None
+
+    def set_server(self, server):
+        self.server = server
+
+    def trigger_event(self, event, *args):
+        handler_name = 'on_' + event
+        if hasattr(self, handler_name):
+            return getattr(self, handler_name)(*args)
+
+    def emit(self, event, data=None, room=None, skip_sid=None, namespace=None,
+             callback=None):
+        """Emit a custom event to one or more connected clients.
+
+        The only difference with the :func:`socketio.Server.emit` method is
+        that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.emit(event, data=data, room=room, skip_sid=skip_sid,
+                                namespace=namespace or self.namespace,
+                                callback=callback)
+
+    def send(self, data, room=None, skip_sid=None, namespace=None,
+             callback=None):
+        """Send a message to one or more connected clients.
+
+        The only difference with the :func:`socketio.Server.send` method is
+        that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.send(data, room=room, skip_sid=skip_sid,
+                                namespace=namespace or self.namespace,
+                                callback=callback)
+
+    def enter_room(self, sid, room, namespace=None):
+        """Enter a room.
+
+        The only difference with the :func:`socketio.Server.enter_room` method
+        is that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.enter_room(sid, room,
+                                      namespace=namespace or self.namespace)
+
+    def leave_room(self, sid, room, namespace=None):
+        """Leave a room.
+
+        The only difference with the :func:`socketio.Server.leave_room` method
+        is that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.leave_room(sid, room,
+                                      namespace=namespace or self.namespace)
+
+    def close_room(self, room, namespace=None):
+        """Close a room.
+
+        The only difference with the :func:`socketio.Server.close_room` method
+        is that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.close_room(room,
+                                      namespace=namespace or self.namespace)
+
+    def rooms(self, sid, namespace=None):
+        """Return the rooms a client is in.
+
+        The only difference with the :func:`socketio.Server.rooms` method is
+        that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.rooms(sid, namespace=namespace or self.namespace)
+
+    def disconnect(self, sid, namespace=None):
+        """Disconnect a client.
+
+        The only difference with the :func:`socketio.Server.disconnect` method
+        is that when the ``namespace`` argument is not given the namespace
+        associated with the class is used.
+        """
+        return self.server.disconnect(sid,
+                                      namespace=namespace or self.namespace)

--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -13,7 +13,7 @@ class Namespace(object):
     def __init__(self, namespace=None):
         self.name = namespace or '/'
         self.server = None
-        self.middlewares = []
+        self.interceptors = []
 
     def _set_server(self, server):
         self.server = server

--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -14,6 +14,7 @@ class Namespace(object):
         self.name = namespace or '/'
         self.server = None
         self.interceptors = []
+        self.ignore_interceptors = []
 
     def _set_server(self, server):
         self.server = server

--- a/socketio/util.py
+++ b/socketio/util.py
@@ -1,16 +1,16 @@
-def apply_middleware(middleware):
+def apply_interceptor(interceptor):
     """Returns a decorator for event handlers that adds the given
-    middleware to the handler decorated with it.
+    interceptor to the handler decorated with it.
 
-    :param middleware: The middleware to add
+    :param interceptor: The interceptor to add
 
     Ensure that you only add well-behaving decorators after this one
     (meaning such that preserve attributes) because you'll loose them
     otherwise.
     """
     def wrapper(handler):
-        if not hasattr(handler, '_sio_middlewares'):
-            handler._sio_middlewares = []
-        handler._sio_middlewares.append(middleware)
+        if not hasattr(handler, '_sio_interceptors'):
+            handler._sio_interceptors = []
+        handler._sio_interceptors.append(interceptor)
         return handler
     return wrapper

--- a/socketio/util.py
+++ b/socketio/util.py
@@ -14,3 +14,21 @@ def apply_interceptor(interceptor):
         handler._sio_interceptors.append(interceptor)
         return handler
     return wrapper
+
+
+def ignore_interceptor(interceptor):
+    """Returns a decorator for event handlers that ignores the given
+    interceptor for the handler decorated with it.
+
+    :param interceptor: The interceptor to ignore
+
+    Ensure that you only add well-behaving decorators after this one
+    (meaning such that preserve attributes) because you'll loose them
+    otherwise.
+    """
+    def wrapper(handler):
+        if not hasattr(handler, '_sio_ignore_interceptors'):
+            handler._sio_ignore_interceptors = []
+        handler._sio_ignore_interceptors.append(interceptor)
+        return handler
+    return wrapper

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,129 @@
+import unittest
+import six
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
+
+from socketio import namespace
+
+
+class TestNamespace(unittest.TestCase):
+    def test_connect_event(self):
+        result = {}
+
+        class MyNamespace(namespace.Namespace):
+            def on_connect(self, sid, environ):
+                result['result'] = (sid, environ)
+
+        ns = MyNamespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.trigger_event('connect', 'sid', {'foo': 'bar'})
+        self.assertEqual(result['result'], ('sid', {'foo': 'bar'}))
+
+    def test_disconnect_event(self):
+        result = {}
+
+        class MyNamespace(namespace.Namespace):
+            def on_disconnect(self, sid):
+                result['result'] = sid
+
+        ns = MyNamespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.trigger_event('disconnect', 'sid')
+        self.assertEqual(result['result'], 'sid')
+
+    def test_event(self):
+        result = {}
+
+        class MyNamespace(namespace.Namespace):
+            def on_custom_message(self, sid, data):
+                result['result'] = (sid, data)
+
+        ns = MyNamespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.trigger_event('custom_message', 'sid', {'data': 'data'})
+        self.assertEqual(result['result'], ('sid', {'data': 'data'}))
+
+    def test_event_not_found(self):
+        result = {}
+
+        class MyNamespace(namespace.Namespace):
+            def on_custom_message(self, sid, data):
+                result['result'] = (sid, data)
+
+        ns = MyNamespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.trigger_event('another_custom_message', 'sid', {'data': 'data'})
+        self.assertEqual(result, {})
+
+    def test_emit(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.emit('ev', data='data', room='room', skip_sid='skip',
+                callback='cb')
+        ns.server.emit.assert_called_with(
+            'ev', data='data', room='room', skip_sid='skip', namespace='/foo',
+            callback='cb')
+        ns.emit('ev', data='data', room='room', skip_sid='skip',
+                namespace='/bar', callback='cb')
+        ns.server.emit.assert_called_with(
+            'ev', data='data', room='room', skip_sid='skip', namespace='/bar',
+            callback='cb')
+
+    def test_send(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.send(data='data', room='room', skip_sid='skip', callback='cb')
+        ns.server.send.assert_called_with(
+            'data', room='room', skip_sid='skip', namespace='/foo',
+            callback='cb')
+        ns.send(data='data', room='room', skip_sid='skip', namespace='/bar',
+                callback='cb')
+        ns.server.send.assert_called_with(
+            'data', room='room', skip_sid='skip', namespace='/bar',
+            callback='cb')
+
+    def test_enter_room(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.enter_room('sid', 'room')
+        ns.server.enter_room.assert_called_with('sid', 'room',
+                                                namespace='/foo')
+        ns.enter_room('sid', 'room', namespace='/bar')
+        ns.server.enter_room.assert_called_with('sid', 'room',
+                                                namespace='/bar')
+
+    def test_leave_room(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.leave_room('sid', 'room')
+        ns.server.leave_room.assert_called_with('sid', 'room',
+                                                namespace='/foo')
+        ns.leave_room('sid', 'room', namespace='/bar')
+        ns.server.leave_room.assert_called_with('sid', 'room',
+                                                namespace='/bar')
+
+    def test_close_room(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.close_room('room')
+        ns.server.close_room.assert_called_with('room', namespace='/foo')
+        ns.close_room('room', namespace='/bar')
+        ns.server.close_room.assert_called_with('room', namespace='/bar')
+
+    def test_rooms(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.rooms('sid')
+        ns.server.rooms.assert_called_with('sid', namespace='/foo')
+        ns.rooms('sid', namespace='/bar')
+        ns.server.rooms.assert_called_with('sid', namespace='/bar')
+
+    def test_disconnect(self):
+        ns = namespace.Namespace('/foo')
+        ns.set_server(mock.MagicMock())
+        ns.disconnect('sid')
+        ns.server.disconnect.assert_called_with('sid', namespace='/foo')
+        ns.disconnect('sid', namespace='/bar')
+        ns.server.disconnect.assert_called_with('sid', namespace='/bar')


### PR DESCRIPTION
This deals with the concept of event handler middlewares. I wrote a chapter in the docs about them. Basically it's a way to add before/after event handlers on three layers for fine-grained control: These layers can alter the arguments the event handler will get or its return value transparently or completely abort execution, returning something else.
- at server layer for _every_ event by adding the middleware to `socketio.Server.middlewares`
- at namespace layer by adding the middleware to `socketio.Namespace.middlewares`
- at the event handler layer by decorating an event handler with `@util.apply_middleware(...)`

Finally, when the event is triggered, the `socketio.Server._trigger_event` method collects middlewares for the used event handler from these three layers (from least to most specific one) and applies them on the handler before execution.

I wrote a test for it that is commented and it works well.
