### PR TITLE
Clarify level of separation of namespaces

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -211,7 +211,7 @@ their event handlers and rooms, using the optional ``namespace`` argument
 available in all the methods in the :class:`socketio.Server` class.
 
 When the ``namespace`` argument is omitted, set to ``None`` or to ``'/'``, the
-default namespace, representing the physical connection, is used.
+default namespace, is used.
 
 Class-Based Namespaces
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -204,11 +204,11 @@ as a pathname following the hostname and port. For example, connecting to
 *http://example.com:8000/chat* would open a connection to the namespace
 */chat*.
 
-Each namespace is handled independently from the others, with separate event
-handlers and rooms. It is important that applications that use multiple
-namespaces specify the correct namespace when setting up their event handlers
-and rooms, using the optional ``namespace`` argument available in all the
-methods in the :class:`socketio.Server` class.
+Each namespace is handled independently from the others, with separate session
+IDs (``sid``s), event handlers and rooms. It is important that applications
+that use multiple namespaces specify the correct namespace when setting up
+their event handlers and rooms, using the optional ``namespace`` argument
+available in all the methods in the :class:`socketio.Server` class.
 
 When the ``namespace`` argument is omitted, set to ``None`` or to ``'/'``, the
 default namespace, representing the physical connection, is used.


### PR DESCRIPTION
1. Add mentioning, that each namespace has own SID's. 
   To make it clear for a reader, that they are not global.
2. Remove the phrase, that the default namespace represents "physical connection".
    - [Socket.IO docs][1] does not mention anything like that.
    - It makes user think, that the default namespace is somehow special and maybe a "catch-all" namespace.
    - What is "physical connection" and how it represents is? Socket.IO is a pretty high level protocol, there is nothing in it that represents anything "physical".


[1]: http://socket.io/docs/rooms-and-namespaces/#

It is related to #61.