### PR TITLE
Fix namespace hyphens

### DIFF
--- a/socketio/packet.py
+++ b/socketio/packet.py
@@ -78,12 +78,21 @@ class Packet(object):
         self.namespace = None
         self.data = None
         ep = ep[1:]
-        dash = (ep + '-').find('-')
-        comma = (ep + ',').find(',')
         attachment_count = 0
-        if dash < comma:
-            attachment_count = int(ep[0:dash])
-            ep = ep[dash + 1:]
+        if ep and ep[0].isdigit():
+            # build number so it's either attachment count or id
+            ind = 0
+            ep_len = len(ep)
+            while ind < ep_len and ep[ind].isdigit():
+                ind += 1
+            num = int(ep[0:ind])
+            ep = ep[ind:]
+            if ep:
+                if ep[0] == '-':
+                    attachment_count = num
+                    ep = ep[1:]
+                else:
+                    self.id = num
         if ep and ep[0:1] == '/':
             sep = ep.find(',')
             if sep == -1:

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -106,6 +106,17 @@ class TestPacket(unittest.TestCase):
         self.assertEqual(pkt.namespace, '/bar')
         self.assertEqual(pkt.encode(), '2/bar')
 
+    def test_encode_namespace_with_hyphens(self):
+        pkt = packet.Packet(packet_type=packet.EVENT,
+                            data=[six.text_type('foo')], namespace='/b-a-r')
+        self.assertEqual(pkt.namespace, '/b-a-r')
+        self.assertEqual(pkt.encode(), '2/b-a-r,["foo"]')
+
+    def test_decode_namespace_with_hyphens(self):
+        pkt = packet.Packet(encoded_packet='2/b-a-r,["foo"]')
+        self.assertEqual(pkt.namespace, '/b-a-r')
+        self.assertEqual(pkt.encode(), '2/b-a-r,["foo"]')
+
     def test_encode_id(self):
         pkt = packet.Packet(packet_type=packet.EVENT,
                             data=[six.text_type('foo')], id=123)


### PR DESCRIPTION
Hello
There is [an issue](https://github.com/miguelgrinberg/Flask-SocketIO/issues/392) with hyphens namespace in Flask-SocketIO repo which is actually python-socketio bug. I think this PR will fix it. I also briefly compared decode time with these changes and looks like it performs a little bit faster.
Please, review. 
Thank you
