### PR TITLE
assigning local ret variable to none if the asyncio task is canceled

### DIFF
--- a/socketio/asyncio_namespace.py
+++ b/socketio/asyncio_namespace.py
@@ -36,7 +36,7 @@ class AsyncNamespace(namespace.Namespace):
                 try:
                     ret = await handler(*args)
                 except asyncio.CancelledError:  # pragma: no cover
-                    pass
+                    ret = None
             else:
                 ret = handler(*args)
             return ret


### PR DESCRIPTION
In the async namespace's trigger_event routine the ret variable is not assigned any value if the async task is canceled. This causes some IMO unnecessary exceptions. 
https://github.com/miguelgrinberg/python-socketio/blob/ce44133acd66d53d607937d04261668fbc2aa328/socketio/asyncio_namespace.py#L36-L39

I have assigned it to none as it is done in 
https://github.com/miguelgrinberg/python-socketio/blob/3b702da590a0788d370bfd08c7db9bef7d041cf9/socketio/asyncio_server.py#L324-L327