### PR TITLE
added after_connect event triggering

### DIFF
--- a/socketio/server.py
+++ b/socketio/server.py
@@ -428,6 +428,8 @@ class Server(object):
         else:
             self._send_packet(sid, packet.Packet(packet.CONNECT,
                                                  namespace=namespace))
+            self._trigger_event('after_connect', namespace, sid,
+                               self.environ[sid])
 
     def _handle_disconnect(self, sid, namespace):
         """Handle a client disconnect."""


### PR DESCRIPTION
There are cases when you want to accept connection on connect event and then after that do some additional work, for example send the latest updates to user which has just authenticated. This is not possible to do on connect event because in order to send events to the client you need to accept it's connection but for that you need to return from connect event handler and thus you cannot do anything after return.
Without this event you are forced to do this by either accepting all connections and doing authentication on another event or setting up messaging broker and delaying tasks from connect event for example with celery.