### PR TITLE
Integration with Kafka #507

### DIFF
--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -23,7 +23,7 @@ else:  # pragma: no cover
 __version__ = '1.9.0'
 
 __all__ = ['__version__', 'Middleware', 'Server', 'BaseManager',
-           'PubSubManager', 'KombuManager', 'RedisManager', 'KafkaManager', 
+           'PubSubManager', 'KombuManager', 'RedisManager', 'KafkaManager',
            'ZmqManager', 'Namespace']
 if AsyncServer is not None:  # pragma: no cover
     __all__ += ['AsyncServer', 'AsyncNamespace', 'AsyncManager',

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -24,7 +24,7 @@ __version__ = '1.9.0'
 
 __all__ = ['__version__', 'Middleware', 'Server',
            'BaseManager', 'PubSubManager',
-           'KombuManager', 'RedisManager', 'KafkaManager', 'ZmqManager', 
+           'KombuManager', 'RedisManager', 'KafkaManager', 'ZmqManager',
            'Namespace']
 if AsyncServer is not None:  # pragma: no cover
     __all__ += ['AsyncServer', 'AsyncNamespace', 'AsyncManager',

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -22,9 +22,10 @@ else:  # pragma: no cover
 
 __version__ = '1.9.0'
 
-__all__ = ['__version__', 'Middleware', 'Server', 'BaseManager',
-           'PubSubManager', 'KombuManager', 'RedisManager', 'KafkaManager',
-           'ZmqManager', 'Namespace']
+__all__ = ['__version__', 'Middleware', 'Server',
+           'BaseManager', 'PubSubManager',
+           'KombuManager', 'RedisManager', 'KafkaManager', 'ZmqManager', 
+           'Namespace']
 if AsyncServer is not None:  # pragma: no cover
     __all__ += ['AsyncServer', 'AsyncNamespace', 'AsyncManager',
                 'AsyncRedisManager']

--- a/socketio/__init__.py
+++ b/socketio/__init__.py
@@ -5,6 +5,7 @@ from .base_manager import BaseManager
 from .pubsub_manager import PubSubManager
 from .kombu_manager import KombuManager
 from .redis_manager import RedisManager
+from .kafka_manager import KafkaManager
 from .zmq_manager import ZmqManager
 from .server import Server
 from .namespace import Namespace
@@ -22,8 +23,8 @@ else:  # pragma: no cover
 __version__ = '1.9.0'
 
 __all__ = ['__version__', 'Middleware', 'Server', 'BaseManager',
-           'PubSubManager', 'KombuManager', 'RedisManager', 'ZmqManager',
-           'Namespace']
+           'PubSubManager', 'KombuManager', 'RedisManager', 'KafkaManager', 
+           'ZmqManager', 'Namespace']
 if AsyncServer is not None:  # pragma: no cover
     __all__ += ['AsyncServer', 'AsyncNamespace', 'AsyncManager',
                 'AsyncRedisManager']

--- a/socketio/kafka_manager.py
+++ b/socketio/kafka_manager.py
@@ -1,0 +1,110 @@
+import logging
+import pickle
+import time
+
+try:
+    import redis
+except ImportError:
+    redis = None
+
+from .pubsub_manager import PubSubManager
+
+logger = logging.getLogger('socketio')
+
+
+class KafkaManager(PubSubManager):  # pragma: no cover
+    """Redis based client manager.
+
+    This class implements a Redis backend for event sharing across multiple
+    processes. Only kept here as one more example of how to build a custom
+    backend, since the kombu backend is perfectly adequate to support a Redis
+    message queue.
+
+    To use a Redis backend, initialize the :class:`Server` instance as
+    follows::
+
+        url = 'redis://hostname:port/0'
+        server = socketio.Server(client_manager=socketio.RedisManager(url))
+
+    :param url: The connection URL for the Redis server. For a default Redis
+                store running on the same host, use ``redis://``.
+    :param channel: The channel name on which the server sends and receives
+                    notifications. Must be the same in all the servers.
+    :param write_only: If set ot ``True``, only initialize to emit events. The
+                       default of ``False`` initializes the class for emitting
+                       and receiving.
+    """
+    name = 'redis'
+
+    def __init__(self, url='redis://localhost:6379/0', channel='socketio',
+                 write_only=False):
+        if redis is None:
+            raise RuntimeError('Redis package is not installed '
+                               '(Run "pip install redis" in your '
+                               'virtualenv).')
+        self.redis_url = url
+        self._redis_connect()
+        super(RedisManager, self).__init__(channel=channel,
+                                           write_only=write_only)
+
+    def initialize(self):
+        super(RedisManager, self).initialize()
+
+        monkey_patched = True
+        if self.server.async_mode == 'eventlet':
+            from eventlet.patcher import is_monkey_patched
+            monkey_patched = is_monkey_patched('socket')
+        elif 'gevent' in self.server.async_mode:
+            from gevent.monkey import is_module_patched
+            monkey_patched = is_module_patched('socket')
+        if not monkey_patched:
+            raise RuntimeError(
+                'Redis requires a monkey patched socket library to work '
+                'with ' + self.server.async_mode)
+
+    def _redis_connect(self):
+        self.redis = redis.Redis.from_url(self.redis_url)
+        self.pubsub = self.redis.pubsub()
+
+    def _publish(self, data):
+        retry = True
+        while True:
+            try:
+                if not retry:
+                    self._redis_connect()
+                return self.redis.publish(self.channel, pickle.dumps(data))
+            except redis.exceptions.ConnectionError:
+                if retry:
+                    logger.error('Cannot publish to redis... retrying')
+                    retry = False
+                else:
+                    logger.error('Cannot publish to redis... giving up')
+                    break
+
+    def _redis_listen_with_retries(self):
+        retry_sleep = 1
+        connect = False
+        while True:
+            try:
+                if connect:
+                    self._redis_connect()
+                    self.pubsub.subscribe(self.channel)
+                for message in self.pubsub.listen():
+                    yield message
+            except redis.exceptions.ConnectionError:
+                logger.error('Cannot receive from redis... '
+                             'retrying in {} secs'.format(retry_sleep))
+                connect = True
+                time.sleep(retry_sleep)
+                retry_sleep *= 2
+                if retry_sleep > 60:
+                    retry_sleep = 60
+
+    def _listen(self):
+        channel = self.channel.encode('utf-8')
+        self.pubsub.subscribe(self.channel)
+        for message in self._redis_listen_with_retries():
+            if message['channel'] == channel and \
+                    message['type'] == 'message' and 'data' in message:
+                yield message['data']
+        self.pubsub.unsubscribe(self.channel)

--- a/socketio/kafka_manager.py
+++ b/socketio/kafka_manager.py
@@ -1,7 +1,5 @@
 import logging
 import pickle
-import time
-import json
 
 try:
     import kafka

--- a/socketio/kafka_manager.py
+++ b/socketio/kafka_manager.py
@@ -25,8 +25,9 @@ class KafkaManager(PubSubManager):  # pragma: no cover
 
     :param url: The connection URL for the Kafka server. For a default Kafka
                 store running on the same host, use ``kafka://``.
-    :param channel: The channel name (topic) on which the server sends and receives
-                    notifications. Must be the same in all the servers.
+    :param channel: The channel name (topic) on which the server sends and
+                    receives notifications. Must be the same in all the
+                    servers.
     :param write_only: If set ot ``True``, only initialize to emit events. The
                        default of ``False`` initializes the class for emitting
                        and receiving.
@@ -48,16 +49,13 @@ class KafkaManager(PubSubManager):  # pragma: no cover
         self.consumer = kafka.KafkaConsumer(self.channel,
                                             bootstrap_servers=self.kafka_url)
 
-
     def _publish(self, data):
         self.producer.send(self.channel, value=pickle.dumps(data))
         self.producer.flush()
 
-
     def _kafka_listen(self):
         for message in self.consumer:
             yield message
-
 
     def _listen(self):
         for message in self._kafka_listen():


### PR DESCRIPTION
Hi, 

After reading this issue : https://github.com/miguelgrinberg/Flask-SocketIO/issues/507, I created a custom backend to use python-socketio with Kafka.

Currently it's worked fine with kafka-python. I plan to add the capability to choose between confluent-kafka-python or python-kafka (another PR will be coming soon if this one is correct).

I test it on a kubernetes cluster with dozen backends.

Please, tell me if any corrections are necessary. I will be happy to improve this feature.

PS : Simultaneously, I made a PR on Flask-SocketIO.