### PR TITLE
Update PyPI link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,4 +124,4 @@ Resources
 -  `PyPI`_
 
 .. _Documentation: http://python-socketio.readthedocs.io/en/latest/
-.. _PyPI: https://pypi.python.org/pypi/python-socketio
+.. _PyPI: https://pypi.org/project/python-socketio


### PR DESCRIPTION
https://pypi.python.org is deprecated.