### PR TITLE
Logging improvements for write-only connections

### DIFF
--- a/socketio/asyncio_manager.py
+++ b/socketio/asyncio_manager.py
@@ -44,7 +44,7 @@ class AsyncManager(BaseManager):
             callback = self.callbacks[sid][namespace][id]
         except KeyError:
             # if we get an unknown callback we just ignore it
-            self.server.logger.warning('Unknown callback received, ignoring.')
+            self._get_logger().warning('Unknown callback received, ignoring.')
         else:
             del self.callbacks[sid][namespace][id]
         if callback is not None:

--- a/socketio/asyncio_pubsub_manager.py
+++ b/socketio/asyncio_pubsub_manager.py
@@ -24,17 +24,18 @@ class AsyncPubSubManager(AsyncManager):
     """
     name = 'asyncpubsub'
 
-    def __init__(self, channel='socketio', write_only=False):
+    def __init__(self, channel='socketio', write_only=False, logger=None):
         super().__init__()
         self.channel = channel
         self.write_only = write_only
         self.host_id = uuid.uuid4().hex
+        self.logger = logger
 
     def initialize(self):
         super().initialize()
         if not self.write_only:
             self.thread = self.server.start_background_task(self._thread)
-        self.server.logger.info(self.name + ' backend initialized.')
+        self._get_logger().info(self.name + ' backend initialized.')
 
     async def emit(self, event, data, namespace=None, room=None, skip_sid=None,
                    callback=None, **kwargs):

--- a/socketio/asyncio_redis_manager.py
+++ b/socketio/asyncio_redis_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import pickle
 from urllib.parse import urlparse
 
@@ -9,8 +8,6 @@ except ImportError:
     aioredis = None
 
 from .asyncio_pubsub_manager import AsyncPubSubManager
-
-logger = logging.getLogger('socketio')
 
 
 def _parse_redis_url(url):
@@ -52,7 +49,7 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
     name = 'aioredis'
 
     def __init__(self, url='redis://localhost:6379/0', channel='socketio',
-                 write_only=False):
+                 write_only=False, logger=None):
         if aioredis is None:
             raise RuntimeError('Redis package is not installed '
                                '(Run "pip install aioredis" in your '
@@ -60,7 +57,7 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
         self.host, self.port, self.password, self.db = _parse_redis_url(url)
         self.pub = None
         self.sub = None
-        super().__init__(channel=channel, write_only=write_only)
+        super().__init__(channel=channel, write_only=write_only, logger=logger)
 
     async def _publish(self, data):
         retry = True
@@ -74,11 +71,11 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
                                               pickle.dumps(data))
             except (aioredis.RedisError, OSError):
                 if retry:
-                    logger.error('Cannot publish to redis... retrying')
+                    self._get_logger().error('Cannot publish to redis... retrying')
                     self.pub = None
                     retry = False
                 else:
-                    logger.error('Cannot publish to redis... giving up')
+                    self._get_logger().error('Cannot publish to redis... giving up')
                     break
 
     async def _listen(self):
@@ -92,8 +89,8 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
                 self.ch = (await self.sub.subscribe(self.channel))[0]
                 return await self.ch.get()
             except (aioredis.RedisError, OSError):
-                logger.error('Cannot receive from redis... '
-                             'retrying in {} secs'.format(retry_sleep))
+                self._get_logger().error('Cannot receive from redis... '
+                                         'retrying in {} secs'.format(retry_sleep))
                 self.sub = None
                 await asyncio.sleep(retry_sleep)
                 retry_sleep *= 2

--- a/socketio/asyncio_redis_manager.py
+++ b/socketio/asyncio_redis_manager.py
@@ -71,11 +71,13 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
                                               pickle.dumps(data))
             except (aioredis.RedisError, OSError):
                 if retry:
-                    self._get_logger().error('Cannot publish to redis... retrying')
+                    self._get_logger().error('Cannot publish to redis... '
+                                             'retrying')
                     self.pub = None
                     retry = False
                 else:
-                    self._get_logger().error('Cannot publish to redis... giving up')
+                    self._get_logger().error('Cannot publish to redis... '
+                                             'giving up')
                     break
 
     async def _listen(self):
@@ -90,7 +92,8 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
                 return await self.ch.get()
             except (aioredis.RedisError, OSError):
                 self._get_logger().error('Cannot receive from redis... '
-                                         'retrying in {} secs'.format(retry_sleep))
+                                         'retrying in '
+                                         '{} secs'.format(retry_sleep))
                 self.sub = None
                 await asyncio.sleep(retry_sleep)
                 retry_sleep *= 2

--- a/socketio/base_manager.py
+++ b/socketio/base_manager.py
@@ -1,6 +1,9 @@
 import itertools
+import logging
 
 import six
+
+default_logger = logging.getLogger('socketio')
 
 
 class BaseManager(object):
@@ -13,6 +16,7 @@ class BaseManager(object):
     subclasses.
     """
     def __init__(self):
+        self.logger = None
         self.server = None
         self.rooms = {}
         self.callbacks = {}
@@ -141,7 +145,7 @@ class BaseManager(object):
             callback = self.callbacks[sid][namespace][id]
         except KeyError:
             # if we get an unknown callback we just ignore it
-            self.server.logger.warning('Unknown callback received, ignoring.')
+            self._get_logger().warning('Unknown callback received, ignoring.')
         else:
             del self.callbacks[sid][namespace][id]
         if callback is not None:
@@ -157,3 +161,16 @@ class BaseManager(object):
         id = six.next(self.callbacks[sid][namespace][0])
         self.callbacks[sid][namespace][id] = callback
         return id
+
+    def _get_logger(self):
+        """Get the appropriate logger
+
+        Prevents uninitialized servers in write-only mode failing because of a missing logger.
+        """
+
+        if self.logger:
+            return self.logger
+        elif self.server:
+            return self.server.logger
+        else:
+            return default_logger

--- a/socketio/base_manager.py
+++ b/socketio/base_manager.py
@@ -165,7 +165,7 @@ class BaseManager(object):
     def _get_logger(self):
         """Get the appropriate logger
 
-        Prevents uninitialized servers in write-only mode failing because of a missing logger.
+        Prevents uninitialized servers in write-only mode from failing.
         """
 
         if self.logger:

--- a/socketio/kombu_manager.py
+++ b/socketio/kombu_manager.py
@@ -38,12 +38,12 @@ class KombuManager(PubSubManager):  # pragma: no cover
     name = 'kombu'
 
     def __init__(self, url='amqp://guest:guest@localhost:5672//',
-                 channel='socketio', write_only=False):
+                 channel='socketio', write_only=False, logger=None):
         if kombu is None:
             raise RuntimeError('Kombu package is not installed '
                                '(Run "pip install kombu" in your '
                                'virtualenv).')
-        super(KombuManager, self).__init__(channel=channel)
+        super(KombuManager, self).__init__(channel=channel, write_only=write_only, logger=logger)
         self.url = url
         self.producer = self._producer()
 
@@ -78,7 +78,7 @@ class KombuManager(PubSubManager):  # pragma: no cover
         return self._connection().Producer(exchange=self._exchange())
 
     def __error_callback(self, exception, interval):
-        self.server.logger.exception('Sleeping {}s'.format(interval))
+        self._get_logger().exception('Sleeping {}s'.format(interval))
 
     def _publish(self, data):
         connection = self._connection()
@@ -99,5 +99,5 @@ class KombuManager(PubSubManager):  # pragma: no cover
                         message.ack()
                         yield message.payload
             except connection.connection_errors:
-                self.server.logger.exception("Connection error "
+                self._get_logger().exception("Connection error "
                                              "while reading from queue")

--- a/socketio/kombu_manager.py
+++ b/socketio/kombu_manager.py
@@ -43,7 +43,9 @@ class KombuManager(PubSubManager):  # pragma: no cover
             raise RuntimeError('Kombu package is not installed '
                                '(Run "pip install kombu" in your '
                                'virtualenv).')
-        super(KombuManager, self).__init__(channel=channel, write_only=write_only, logger=logger)
+        super(KombuManager, self).__init__(channel=channel,
+                                           write_only=write_only,
+                                           logger=logger)
         self.url = url
         self.producer = self._producer()
 

--- a/socketio/pubsub_manager.py
+++ b/socketio/pubsub_manager.py
@@ -24,17 +24,18 @@ class PubSubManager(BaseManager):
     """
     name = 'pubsub'
 
-    def __init__(self, channel='socketio', write_only=False):
+    def __init__(self, channel='socketio', write_only=False, logger=None):
         super(PubSubManager, self).__init__()
         self.channel = channel
         self.write_only = write_only
         self.host_id = uuid.uuid4().hex
+        self.logger = logger
 
     def initialize(self):
         super(PubSubManager, self).initialize()
         if not self.write_only:
             self.thread = self.server.start_background_task(self._thread)
-        self.server.logger.info(self.name + ' backend initialized.')
+        self._get_logger().info(self.name + ' backend initialized.')
 
     def emit(self, event, data, namespace=None, room=None, skip_sid=None,
              callback=None, **kwargs):

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -37,7 +37,7 @@ class RedisManager(PubSubManager):  # pragma: no cover
     name = 'redis'
 
     def __init__(self, url='redis://localhost:6379/0', channel='socketio',
-                 write_only=False):
+                 write_only=False, logger=None):
         if redis is None:
             raise RuntimeError('Redis package is not installed '
                                '(Run "pip install redis" in your '
@@ -45,7 +45,8 @@ class RedisManager(PubSubManager):  # pragma: no cover
         self.redis_url = url
         self._redis_connect()
         super(RedisManager, self).__init__(channel=channel,
-                                           write_only=write_only)
+                                           write_only=write_only,
+                                           logger=logger)
 
     def initialize(self):
         super(RedisManager, self).initialize()

--- a/socketio/zmq_manager.py
+++ b/socketio/zmq_manager.py
@@ -50,7 +50,8 @@ class ZmqManager(PubSubManager):  # pragma: no cover
 
     def __init__(self, url='zmq+tcp://localhost:5555+5556',
                  channel='socketio',
-                 write_only=False):
+                 write_only=False,
+                 logger=None):
         if zmq is None:
             raise RuntimeError('zmq package is not installed '
                                '(Run "pip install pyzmq" in your '
@@ -76,7 +77,8 @@ class ZmqManager(PubSubManager):  # pragma: no cover
         self.sub = sub
         self.channel = channel
         super(ZmqManager, self).__init__(channel=channel,
-                                         write_only=write_only)
+                                         write_only=write_only,
+                                         logger=logger)
 
     def _publish(self, data):
         pickled_data = pickle.dumps(

--- a/tests/test_pubsub_manager.py
+++ b/tests/test_pubsub_manager.py
@@ -48,11 +48,13 @@ class TestBaseManager(unittest.TestCase):
         self.assertEqual(pm._get_logger(), logging.getLogger('socketio'))
 
     def test_write_only_with_provided_logger(self):
-        pm = pubsub_manager.PubSubManager(write_only=True, logger=logging.getLogger('new_logger'))
+        test_logger = logging.getLogger('new_logger')
+        pm = pubsub_manager.PubSubManager(write_only=True,
+                                          logger=test_logger)
         pm.initialize()
         self.assertEqual(pm.channel, 'socketio')
         self.assertEqual(len(pm.host_id), 32)
-        self.assertEqual(pm._get_logger(), logging.getLogger('new_logger'))
+        self.assertEqual(pm._get_logger(), test_logger)
 
     def test_emit(self):
         self.pm.emit('foo', 'bar')

--- a/tests/test_pubsub_manager.py
+++ b/tests/test_pubsub_manager.py
@@ -1,5 +1,6 @@
 import functools
 import unittest
+import logging
 
 import six
 if six.PY3:
@@ -38,6 +39,20 @@ class TestBaseManager(unittest.TestCase):
         self.assertEqual(pm.channel, 'socketio')
         self.assertEqual(len(pm.host_id), 32)
         self.assertEqual(pm.server.start_background_task.call_count, 0)
+
+    def test_write_only_default_logger(self):
+        pm = pubsub_manager.PubSubManager(write_only=True)
+        pm.initialize()
+        self.assertEqual(pm.channel, 'socketio')
+        self.assertEqual(len(pm.host_id), 32)
+        self.assertEqual(pm._get_logger(), logging.getLogger('socketio'))
+
+    def test_write_only_with_provided_logger(self):
+        pm = pubsub_manager.PubSubManager(write_only=True, logger=logging.getLogger('new_logger'))
+        pm.initialize()
+        self.assertEqual(pm.channel, 'socketio')
+        self.assertEqual(len(pm.host_id), 32)
+        self.assertEqual(pm._get_logger(), logging.getLogger('new_logger'))
 
     def test_emit(self):
         self.pm.emit('foo', 'bar')


### PR DESCRIPTION
While trying to emit from the standalone, write-only `KombuManager` (using the example from the docs), I kept running into this exception:

```
AttributeError: ‘NoneType’ object has no attribute ‘logger’
```

It looks like logging inside all of the client managers depends on the logger created when the server was instantiated, but that is `None` when the manager is used by itself in write-only mode. The test for write-only sets a mock server (and thus a default logger), so it doesn't fail in the tests.

This code should address that, creating a new option to set the logger for write-only managers, using the server logger if it exists, and falling back to the same default logger as the server. It also fixes what looks like a bug where `KombuManager` was not passing `write_only` up to the `PubSubManager` and adds a test to ensure loggers are being set. Logging in `AsyncRedisManager` was done a little differently; I'm not sure if that was intentional (no option, always default logger), but I made it consistent with the others.