### PR TITLE
Fix synchronization issue in SocketIO

### DIFF
--- a/socketio/base_manager.py
+++ b/socketio/base_manager.py
@@ -71,7 +71,7 @@ class BaseManager(object):
         if namespace not in self.rooms:
             return
         rooms = []
-        for room_name, room in six.iteritems(self.rooms[namespace]):
+        for room_name, room in six.iteritems(self.rooms[namespace].copy()):
             if sid in room:
                 rooms.append(room_name)
         for room in rooms:


### PR DESCRIPTION
Occasionally with our single-threaded SocketIO application, we get the following error:

```
2018-11-02 00:26:39,494 engineio ERROR    disconnect handler error
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/engineio/socket.py", line 31, in poll
    packets = [self.queue.get(timeout=self.server.ping_timeout)]
  File "/usr/lib/python3.6/queue.py", line 172, in get
    raise Empty
queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/engineio/socket.py", line 93, in handle_get_request
    packets = self.poll()
  File "/usr/local/lib/python3.6/dist-packages/engineio/socket.py", line 34, in poll
    raise exceptions.QueueEmpty()
engineio.exceptions.QueueEmpty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/engineio/server.py", line 411, in _trigger_event
    return self.handlers[event](*args)
  File "/usr/local/lib/python3.6/dist-packages/socketio/server.py", line 535, in _handle_eio_disconnect
    self._handle_disconnect(sid, '/')
  File "/usr/local/lib/python3.6/dist-packages/socketio/server.py", line 445, in _handle_disconnect
    self.manager.disconnect(sid, '/')
  File "/usr/local/lib/python3.6/dist-packages/socketio/base_manager.py", line 70, in disconnect
    for room_name, room in six.iteritems(self.rooms[namespace]):
RuntimeError: dictionary changed size during iteration
```

This fixes the issue.