### PR TITLE
Update sanic version in requirements.txt

### DIFF
--- a/examples/server/sanic/requirements.txt
+++ b/examples/server/sanic/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==0.3.0
 httptools==0.0.9
 python_engineio
 python_socketio
-sanic==0.3.1
+sanic==0.8
 six==1.10.0
 ujson==1.35
 uvloop==0.8.0


### PR DESCRIPTION
Sanic example doesn't work because of the server version specified in requirements (0.3.1).

Traceback (most recent call last):
  File "app.py", line 23, in <module>
    @app.listener('before_server_start')
AttributeError: 'Sanic' object has no attribute 'listener'

The code starts to work from 0.7 sanic version.