### PR TITLE
fix the bug that socketio can't emit event disconnnect when call  disconnect() 

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -45,7 +45,7 @@ The example that follows shows a simple Python client:
 Client Features
 ---------------
 
-- Can connect to other Socket.IO complaint servers besides the one in
+- Can connect to other Socket.IO compliant servers besides the one in
   this package.
 - Compatible with Python 2.7 and 3.5+.
 - Two versions of the client, one for standard Python and another for

--- a/socketio/asyncio_client.py
+++ b/socketio/asyncio_client.py
@@ -86,7 +86,7 @@ class AsyncClient(client.Client):
 
         Example usage::
 
-            sio = socketio.Client()
+            sio = socketio.AsyncClient()
             sio.connect('http://localhost:5000')
         """
         self.connection_url = url


### PR DESCRIPTION
fix the bug that socketio can't emit event disconnnect when call  disconnect() 