### PR TITLE
Require target in `call()` method

### DIFF
--- a/socketio/asyncio_server.py
+++ b/socketio/asyncio_server.py
@@ -209,6 +209,8 @@ class AsyncServer(server.Server):
 
         Note 2: this method is a coroutine.
         """
+        if to == None and sid == None:
+            raise TypeError('Missing `to` or `sid`.')
         if not self.async_handlers:
             raise RuntimeError(
                 'Cannot use call() when async_handlers is False.')


### PR DESCRIPTION
The `call` method used to allow both `to` and `sid` to be `None`, however without a target, it broadcasts to all connected clients, and can have very disastrous results in some cases.