### PR TITLE
AsyncPubSubManager does not await for can_disconnect

### DIFF
--- a/socketio/asyncio_pubsub_manager.py
+++ b/socketio/asyncio_pubsub_manager.py
@@ -72,7 +72,7 @@ class AsyncPubSubManager(AsyncManager):
     async def can_disconnect(self, sid, namespace):
         if self.is_connected(sid, namespace):
             # client is in this server, so we can disconnect directly
-            return super().can_disconnect(sid, namespace)
+            return await super().can_disconnect(sid, namespace)
         else:
             # client is in another server, so we post request to the queue
             await self._publish({'method': 'disconnect', 'sid': sid,

--- a/tests/asyncio/test_asyncio_pubsub_manager.py
+++ b/tests/asyncio/test_asyncio_pubsub_manager.py
@@ -118,7 +118,7 @@ class TestAsyncPubSubManager(unittest.TestCase):
 
     def test_can_disconnect(self):
         self.pm.connect('123', '/')
-        self.assertTrue(_run(self.pm.can_disconnect('123', '/')))
+        self.assertTrue(_run(self.pm.can_disconnect('123', '/')) is True)
         _run(self.pm.can_disconnect('123', '/foo'))
         self.pm._publish.mock.assert_called_once_with(
             {'method': 'disconnect', 'sid': '123', 'namespace': '/foo'})


### PR DESCRIPTION
AsyncPubSubManager had an issue which was not caught by the `test_can_disconnect`.

- Fixed the test
- Fixed the issue