### PR TITLE
fix: fixed route path for tornado server

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -619,7 +619,7 @@ Socket.IO::
 
     app = tornado.web.Application(
         [
-            (r"/socketio.io/", socketio.get_tornado_handler(sio)),
+            (r"/socket.io/", socketio.get_tornado_handler(sio)),
         ],
         # ... other application options
     )


### PR DESCRIPTION
In the documentation, in Tornado server section, the route path is specified as `r"/socketio.io/"`, when `r"/socket.io/"` must be.