### PR TITLE
Fix typos in the manual

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -288,7 +288,7 @@ Here is the ``asyncio`` version::
 Note that this function is not a coroutine, since it does not wait for the
 background function to end. The background function must be a coroutine.
 
-The ``sleep()`` method is a second convenince function that is provided for
+The ``sleep()`` method is a second convenience function that is provided for
 the benefit of applications working with background tasks of their own::
 
     sio.sleep(2)

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -683,7 +683,7 @@ The Sanic application is then executed in the usual manner::
         app.run()
 
 It has been reported that the CORS support provided by the Sanic extension
-`sanic-cors <https://github.com/ashleysommer/sanic-cors>`_ is incomaptible with
+`sanic-cors <https://github.com/ashleysommer/sanic-cors>`_ is incompatible with
 this package's own support for this protocol. To disable CORS support in this
 package and let Sanic take full control, initialize the server as follows::
 

--- a/socketio/asyncio_aiopika_manager.py
+++ b/socketio/asyncio_aiopika_manager.py
@@ -30,7 +30,7 @@ class AsyncAioPikaManager(AsyncPubSubManager):  # pragma: no cover
                     notifications. Must be the same in all the servers.
                     With this manager, the channel name is the exchange name
                     in rabbitmq
-    :param write_only: If set ot ``True``, only initialize to emit events. The
+    :param write_only: If set to ``True``, only initialize to emit events. The
                        default of ``False`` initializes the class for emitting
                        and receiving.
     """

--- a/socketio/asyncio_namespace.py
+++ b/socketio/asyncio_namespace.py
@@ -24,7 +24,7 @@ class AsyncNamespace(namespace.Namespace):
 
         In the most common usage, this method is not overloaded by subclasses,
         as it performs the routing of events to methods. However, this
-        method can be overriden if special dispatching rules are needed, or if
+        method can be overridden if special dispatching rules are needed, or if
         having a single method that catches all events is desired.
 
         Note: this method is a coroutine.
@@ -149,7 +149,7 @@ class AsyncClientNamespace(namespace.ClientNamespace):
 
         In the most common usage, this method is not overloaded by subclasses,
         as it performs the routing of events to methods. However, this
-        method can be overriden if special dispatching rules are needed, or if
+        method can be overridden if special dispatching rules are needed, or if
         having a single method that catches all events is desired.
 
         Note: this method is a coroutine.

--- a/socketio/asyncio_redis_manager.py
+++ b/socketio/asyncio_redis_manager.py
@@ -44,7 +44,7 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
                 SSL connection, use ``rediss://``.
     :param channel: The channel name on which the server sends and receives
                     notifications. Must be the same in all the servers.
-    :param write_only: If set ot ``True``, only initialize to emit events. The
+    :param write_only: If set to ``True``, only initialize to emit events. The
                        default of ``False`` initializes the class for emitting
                        and receiving.
     """

--- a/socketio/kafka_manager.py
+++ b/socketio/kafka_manager.py
@@ -28,7 +28,7 @@ class KafkaManager(PubSubManager):  # pragma: no cover
     :param channel: The channel name (topic) on which the server sends and
                     receives notifications. Must be the same in all the
                     servers.
-    :param write_only: If set ot ``True``, only initialize to emit events. The
+    :param write_only: If set to ``True``, only initialize to emit events. The
                        default of ``False`` initializes the class for emitting
                        and receiving.
     """

--- a/socketio/kombu_manager.py
+++ b/socketio/kombu_manager.py
@@ -31,7 +31,7 @@ class KombuManager(PubSubManager):  # pragma: no cover
                 connection URLs.
     :param channel: The channel name on which the server sends and receives
                     notifications. Must be the same in all the servers.
-    :param write_only: If set ot ``True``, only initialize to emit events. The
+    :param write_only: If set to ``True``, only initialize to emit events. The
                        default of ``False`` initializes the class for emitting
                        and receiving.
     :param connection_options: additional keyword arguments to be passed to

--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -10,7 +10,7 @@ class BaseNamespace(object):
 
         In the most common usage, this method is not overloaded by subclasses,
         as it performs the routing of events to methods. However, this
-        method can be overriden if special dispatching rules are needed, or if
+        method can be overridden if special dispatching rules are needed, or if
         having a single method that catches all events is desired.
         """
         handler_name = 'on_' + event

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -30,7 +30,7 @@ class RedisManager(PubSubManager):  # pragma: no cover
                 store running on the same host, use ``redis://``.
     :param channel: The channel name on which the server sends and receives
                     notifications. Must be the same in all the servers.
-    :param write_only: If set ot ``True``, only initialize to emit events. The
+    :param write_only: If set to ``True``, only initialize to emit events. The
                        default of ``False`` initializes the class for emitting
                        and receiving.
     :param redis_options: additional keyword arguments to be passed to


### PR DESCRIPTION
This is a fix to the open issue: https://github.com/miguelgrinberg/python-socketio/issues/598