### PR TITLE
docs: fix simple typo, swich -> switch

### DIFF
--- a/examples/server/wsgi/README.rst
+++ b/examples/server/wsgi/README.rst
@@ -62,7 +62,7 @@ You can then access the application from your web browser at
 ``http://localhost:8000`` (``django_example``).
 
 Near the top of the ``app.py``, ``latency.py`` and ``fiddle.py`` source files
-there is a ``async_mode`` variable that can be edited to swich to the other
+there is a ``async_mode`` variable that can be edited to switch to the other
 asynchornous modes. Accepted values for ``async_mode`` are ``'threading'``,
 ``'eventlet'`` and ``'gevent'``. For ``django_example``, the async mode can be
 set in the ``django_example/socketio_app/views.py`` module.


### PR DESCRIPTION
There is a small typo in examples/server/wsgi/README.rst.

Should read `switch` rather than `swich`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md