### PR TITLE
Adding missing example of async client implementation to intro.rst

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -68,6 +68,47 @@ The example that follows shows a simple Python client:
     sio.connect('http://localhost:5000')
     sio.wait()
 
+Below is a similar client, coded for ``asyncio`` (Python 3.5+ only):
+
+.. code:: python
+
+   import asyncio
+
+   import socketio
+
+
+   sio = socketio.AsyncClient()
+
+   @sio.event
+   async def send_message(data):
+       print('Sending a message:', data)
+       await sio.emit('chat_message', data)
+
+   @sio.on("reply")
+   async def received_message(data):
+       print('Received a message:', data)
+
+   @sio.event
+   async def connect():
+       print("I'm connected! My sid is:", sio.sid)
+       await send_message({"message": "hello!"})
+
+   @sio.event
+   def connect_error():
+       print("The connection failed!")
+
+   @sio.event
+   async def disconnect():
+       print("I'm disconnected!")
+       await sio.disconnect()
+
+
+   if __name__ == '__main__':
+       loop = asyncio.get_event_loop()
+
+       loop.run_until_complete(sio.connect('http://localhost:8080'))
+       loop.run_until_complete(sio.wait())
+
 Client Features
 ---------------
 


### PR DESCRIPTION
Hey Miguel! Noticed that the async client example was missing from intro.rst so I thought I'd add it. Here's a few points:

- The async client integrates with the async server example you provide.
    - Let me know if you think a request for `index.html` would make the client example better. I can add it!
- Tried to base myself on [client.rst](https://github.com/miguelgrinberg/python-socketio/blob/master/docs/client.rst) and [server.rst](https://github.com/miguelgrinberg/python-socketio/blob/master/docs/server.rst) as much as I could for consistency across docs
- Tried to maintain your style wherever I could

Thank you for you work!