### PR TITLE
Catch TimeoutError

### DIFF
--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -78,7 +78,7 @@ class RedisManager(PubSubManager):  # pragma: no cover
                 if not retry:
                     self._redis_connect()
                 return self.redis.publish(self.channel, pickle.dumps(data))
-            except (redis.exceptions.ConnectionError, 
+            except (redis.exceptions.ConnectionError,
                     redis.exceptions.TimeoutError):
                 if retry:
                     logger.error('Cannot publish to redis... retrying')
@@ -97,7 +97,7 @@ class RedisManager(PubSubManager):  # pragma: no cover
                     self.pubsub.subscribe(self.channel)
                 for message in self.pubsub.listen():
                     yield message
-            except (redis.exceptions.ConnectionError, 
+            except (redis.exceptions.ConnectionError,
                     redis.exceptions.TimeoutError) as e:
                 logger.error('Cannot receive from redis ({})... '
                              'retrying in {} secs'.format(e, retry_sleep))

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -78,7 +78,8 @@ class RedisManager(PubSubManager):  # pragma: no cover
                 if not retry:
                     self._redis_connect()
                 return self.redis.publish(self.channel, pickle.dumps(data))
-            except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError) as e:
+            except (redis.exceptions.ConnectionError, 
+                    redis.exceptions.TimeoutError) as e:
                 if retry:
                     logger.error('Cannot publish to redis... retrying')
                     retry = False
@@ -96,7 +97,8 @@ class RedisManager(PubSubManager):  # pragma: no cover
                     self.pubsub.subscribe(self.channel)
                 for message in self.pubsub.listen():
                     yield message
-            except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError) as e:
+            except (redis.exceptions.ConnectionError, 
+                    redis.exceptions.TimeoutError) as e:
                 logger.error('Cannot receive from redis ({})... '
                              'retrying in {} secs'.format(e, retry_sleep))
                 connect = True

--- a/socketio/redis_manager.py
+++ b/socketio/redis_manager.py
@@ -79,7 +79,7 @@ class RedisManager(PubSubManager):  # pragma: no cover
                     self._redis_connect()
                 return self.redis.publish(self.channel, pickle.dumps(data))
             except (redis.exceptions.ConnectionError, 
-                    redis.exceptions.TimeoutError) as e:
+                    redis.exceptions.TimeoutError):
                 if retry:
                     logger.error('Cannot publish to redis... retrying')
                     retry = False


### PR DESCRIPTION
Some network problems could cause TimeoutError, but it isn't handled. Moreover, the thread dies silently without any attempts to recover.

The bug can be also reproduced by setting the socket timeout option in Redis URL.

Probably there are other exceptions that should be retried as well, e.g BusyLoadingError.