### PR TITLE
Use correct packet type with binary payloads and the msgpack serializer (Fixes #811)

### DIFF
--- a/src/socketio/msgpack_packet.py
+++ b/src/socketio/msgpack_packet.py
@@ -3,6 +3,14 @@ from . import packet
 
 
 class MsgPackPacket(packet.Packet):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.packet_type == packet.BINARY_EVENT:
+            self.packet_type = packet.EVENT
+        elif self.packet_type == packet.BINARY_ACK:
+            self.packet_type = packet.ACK
+
     def encode(self):
         """Encode the packet for transmission."""
         return msgpack.dumps(self._to_dict())


### PR DESCRIPTION
As discussed in #811, the wrong (relative to the Javascript implementation) packet types are sent when using msgpack with any binary payloads. The official Socket.IO implementation does not use BINARY_EVENT or BINARY_ACK with msgpack, as all msgpack payloads are binary (so simply EVENT and ACK) are used. This may not be the most elegant fix, but is the fix with the least impact, I think.