### PR TITLE
PubSub: Allow custom encoder

### DIFF
--- a/src/socketio/pubsub_manager.py
+++ b/src/socketio/pubsub_manager.py
@@ -23,12 +23,14 @@ class PubSubManager(BaseManager):
     """
     name = 'pubsub'
 
-    def __init__(self, channel='socketio', write_only=False, logger=None):
+    def __init__(self, channel='socketio', write_only=False, logger=None,
+                 encoder=None):
         super(PubSubManager, self).__init__()
         self.channel = channel
         self.write_only = write_only
         self.host_id = uuid.uuid4().hex
         self.logger = logger
+        self.encoder = encoder
 
     def initialize(self):
         super(PubSubManager, self).initialize()
@@ -151,7 +153,13 @@ class PubSubManager(BaseManager):
             if isinstance(message, dict):
                 data = message
             else:
-                if isinstance(message, bytes):  # pragma: no cover
+                if self.encoder:
+                    try:
+                        data = self.encoder.loads(message)
+                    except:
+                        pass
+                if data is None and \
+                        isinstance(message, bytes):  # pragma: no cover
                     try:
                         data = pickle.loads(message)
                     except:

--- a/src/socketio/redis_manager.py
+++ b/src/socketio/redis_manager.py
@@ -36,21 +36,26 @@ class RedisManager(PubSubManager):  # pragma: no cover
                        and receiving.
     :param redis_options: additional keyword arguments to be passed to
                           ``Redis.from_url()``.
+    :param encoder: The encoder to use for publishing and decoding data,
+                    defaults to pickle.
     """
     name = 'redis'
 
     def __init__(self, url='redis://localhost:6379/0', channel='socketio',
-                 write_only=False, logger=None, redis_options=None):
+                 write_only=False, logger=None, redis_options=None,
+                 encoder=pickle):
         if redis is None:
             raise RuntimeError('Redis package is not installed '
                                '(Run "pip install redis" in your '
                                'virtualenv).')
+        self.encoder = encoder
         self.redis_url = url
         self.redis_options = redis_options or {}
         self._redis_connect()
         super(RedisManager, self).__init__(channel=channel,
                                            write_only=write_only,
-                                           logger=logger)
+                                           logger=logger,
+                                           encoder=encoder)
 
     def initialize(self):
         super(RedisManager, self).initialize()
@@ -78,7 +83,8 @@ class RedisManager(PubSubManager):  # pragma: no cover
             try:
                 if not retry:
                     self._redis_connect()
-                return self.redis.publish(self.channel, pickle.dumps(data))
+                return self.redis.publish(self.channel,
+                                          self.encoder.dumps(data))
             except redis.exceptions.RedisError:
                 if retry:
                     logger.error('Cannot publish to redis... retrying')


### PR DESCRIPTION
Hello.

I wanted to introduce this functionality because i needed the RedisManager to use Json instead of pickle for encoding data, so that other non-python applications listening to the redis channel can decode the data more easily.

I extended this to allow any encoder object to be used basically.


Thanks,


Olivier




