### PR TITLE
Fix connecting to undeclared namespaces

### DIFF
--- a/src/socketio/asyncio_server.py
+++ b/src/socketio/asyncio_server.py
@@ -450,14 +450,17 @@ class AsyncServer(server.Server):
         try:
             if data:
                 success = await self._trigger_event(
-                    'connect', namespace, sid, self.environ[eio_sid], data, safe=False)
+                    'connect', namespace, sid,
+                    self.environ[eio_sid], data, safe=False)
             else:
                 try:
                     success = await self._trigger_event(
-                        'connect', namespace, sid, self.environ[eio_sid], safe=False)
+                        'connect', namespace, sid,
+                        self.environ[eio_sid], safe=False)
                 except TypeError:
                     success = await self._trigger_event(
-                        'connect', namespace, sid, self.environ[eio_sid], None, safe=False)
+                        'connect', namespace, sid,
+                        self.environ[eio_sid], None, safe=False)
         except exceptions.ConnectionRefusedError as exc:
             fail_reason = exc.error_args
             success = False
@@ -507,7 +510,8 @@ class AsyncServer(server.Server):
 
     async def _handle_event_internal(self, server, sid, eio_sid, data,
                                      namespace, id):
-        r = await server._trigger_event(data[0], namespace, sid, *data[1:], safe=True)
+        r = await server._trigger_event(data[0], namespace, sid, *data[1:],
+                                        safe=True)
         if id is not None:
             # send ACK packet with the response returned by the handler
             # tuples are expanded as multiple arguments

--- a/src/socketio/asyncio_server.py
+++ b/src/socketio/asyncio_server.py
@@ -377,7 +377,7 @@ class AsyncServer(server.Server):
             eio_sid = self.manager.pre_disconnect(sid, namespace=namespace)
             await self._send_packet(eio_sid, self.packet_class(
                 packet.DISCONNECT, namespace=namespace))
-            await self._trigger_event('disconnect', namespace, sid)
+            await self._trigger_event('disconnect', namespace, sid, safe=True)
             self.manager.disconnect(sid, namespace=namespace)
 
     async def handle_request(self, *args, **kwargs):
@@ -450,18 +450,20 @@ class AsyncServer(server.Server):
         try:
             if data:
                 success = await self._trigger_event(
-                    'connect', namespace, sid, self.environ[eio_sid], data)
+                    'connect', namespace, sid, self.environ[eio_sid], data, safe=False)
             else:
                 try:
                     success = await self._trigger_event(
-                        'connect', namespace, sid, self.environ[eio_sid])
+                        'connect', namespace, sid, self.environ[eio_sid], safe=False)
                 except TypeError:
                     success = await self._trigger_event(
-                        'connect', namespace, sid, self.environ[eio_sid], None)
+                        'connect', namespace, sid, self.environ[eio_sid], None, safe=False)
         except exceptions.ConnectionRefusedError as exc:
             fail_reason = exc.error_args
             success = False
-
+        except exceptions.NamespaceNotFoundError:
+            fail_reason = "Namespace not found"
+            success = False
         if success is False:
             if self.always_connect:
                 self.manager.pre_disconnect(sid, namespace)
@@ -483,7 +485,7 @@ class AsyncServer(server.Server):
         if not self.manager.is_connected(sid, namespace):  # pragma: no cover
             return
         self.manager.pre_disconnect(sid, namespace=namespace)
-        await self._trigger_event('disconnect', namespace, sid)
+        await self._trigger_event('disconnect', namespace, sid, safe=True)
         self.manager.disconnect(sid, namespace)
 
     async def _handle_event(self, eio_sid, namespace, id, data):
@@ -505,7 +507,7 @@ class AsyncServer(server.Server):
 
     async def _handle_event_internal(self, server, sid, eio_sid, data,
                                      namespace, id):
-        r = await server._trigger_event(data[0], namespace, sid, *data[1:])
+        r = await server._trigger_event(data[0], namespace, sid, *data[1:], safe=True)
         if id is not None:
             # send ACK packet with the response returned by the handler
             # tuples are expanded as multiple arguments
@@ -525,7 +527,7 @@ class AsyncServer(server.Server):
         self.logger.info('received ack from %s [%s]', sid, namespace)
         await self.manager.trigger_callback(sid, id, data)
 
-    async def _trigger_event(self, event, namespace, *args):
+    async def _trigger_event(self, event, namespace, *args, safe):
         """Invoke an application event handler."""
         # first see if we have an explicit handler for the event
         if namespace in self.handlers:
@@ -550,6 +552,8 @@ class AsyncServer(server.Server):
         elif namespace in self.namespace_handlers:
             return await self.namespace_handlers[namespace].trigger_event(
                 event, *args)
+        elif not safe:
+            raise exceptions.NamespaceNotFoundError(namespace, event)
 
     async def _handle_eio_connect(self, eio_sid, environ):
         """Handle the Engine.IO connection event."""

--- a/src/socketio/exceptions.py
+++ b/src/socketio/exceptions.py
@@ -32,3 +32,6 @@ class TimeoutError(SocketIOError):
 
 class BadNamespaceError(SocketIOError):
     pass
+
+class NamespaceNotFoundError(SocketIOError):
+    pass

--- a/src/socketio/exceptions.py
+++ b/src/socketio/exceptions.py
@@ -33,5 +33,6 @@ class TimeoutError(SocketIOError):
 class BadNamespaceError(SocketIOError):
     pass
 
+
 class NamespaceNotFoundError(SocketIOError):
     pass

--- a/src/socketio/server.py
+++ b/src/socketio/server.py
@@ -158,6 +158,7 @@ class Server(object):
         self.always_connect = always_connect
 
         self.async_mode = self.eio.async_mode
+        self.on('connect', namespace='/', handler=lambda sid, environ: True)
 
     def is_asyncio_based(self):
         return False
@@ -662,14 +663,17 @@ class Server(object):
         try:
             if data:
                 success = self._trigger_event(
-                    'connect', namespace, sid, self.environ[eio_sid], data, safe=False)
+                    'connect', namespace, sid,
+                    self.environ[eio_sid], data, safe=False)
             else:
                 try:
                     success = self._trigger_event(
-                        'connect', namespace, sid, self.environ[eio_sid], safe=False)
+                        'connect', namespace, sid,
+                        self.environ[eio_sid], safe=False)
                 except TypeError:
                     success = self._trigger_event(
-                        'connect', namespace, sid, self.environ[eio_sid], None, safe=False)
+                        'connect', namespace, sid,
+                        self.environ[eio_sid], None, safe=False)
         except exceptions.ConnectionRefusedError as exc:
             fail_reason = exc.error_args
             success = False
@@ -720,7 +724,8 @@ class Server(object):
 
     def _handle_event_internal(self, server, sid, eio_sid, data, namespace,
                                id):
-        r = server._trigger_event(data[0], namespace, sid, *data[1:], safe=True)
+        r = server._trigger_event(data[0], namespace, sid, *data[1:],
+                                  safe=True)
         if id is not None:
             # send ACK packet with the response returned by the handler
             # tuples are expanded as multiple arguments

--- a/tests/asyncio/test_asyncio_server.py
+++ b/tests/asyncio/test_asyncio_server.py
@@ -765,6 +765,11 @@ class TestAsyncServer(unittest.TestCase):
     def test_send_with_ack_namespace(self, eio):
         eio.return_value.send = AsyncMock()
         s = asyncio_server.AsyncServer()
+
+        class FooNamespace(asyncio_namespace.AsyncNamespace):
+            pass
+
+        s.register_namespace(FooNamespace("/foo"))
         _run(s._handle_eio_connect('123', 'environ'))
         _run(s._handle_eio_message('123', '0/foo,'))
         cb = mock.MagicMock()
@@ -791,6 +796,11 @@ class TestAsyncServer(unittest.TestCase):
 
         eio.return_value.send = AsyncMock()
         s = asyncio_server.AsyncServer()
+
+        class MyNamespace(asyncio_namespace.AsyncNamespace):
+            pass
+
+        s.register_namespace(MyNamespace("/ns"))
         s.eio.get_session = fake_get_session
         s.eio.save_session = fake_save_session
 
@@ -842,6 +852,11 @@ class TestAsyncServer(unittest.TestCase):
         eio.return_value.send = AsyncMock()
         eio.return_value.disconnect = AsyncMock()
         s = asyncio_server.AsyncServer()
+
+        class FooNamespace(asyncio_namespace.AsyncNamespace):
+            pass
+
+        s.register_namespace(FooNamespace("/foo"))
         _run(s._handle_eio_connect('123', 'environ'))
         _run(s._handle_eio_message('123', '0/foo,'))
         _run(s.disconnect('1', namespace='/foo'))

--- a/tests/common/test_server.py
+++ b/tests/common/test_server.py
@@ -675,6 +675,11 @@ class TestServer(unittest.TestCase):
 
     def test_send_with_ack_namespace(self, eio):
         s = server.Server()
+
+        class FooNamespace(namespace.Namespace):
+            pass
+
+        s.register_namespace(FooNamespace("/foo"))
         s._handle_eio_connect('123', 'environ')
         s._handle_eio_message('123', '0/foo,')
         cb = mock.MagicMock()
@@ -696,6 +701,11 @@ class TestServer(unittest.TestCase):
             fake_session = session
 
         s = server.Server()
+
+        class MyNamespace(namespace.Namespace):
+            pass
+
+        s.register_namespace(MyNamespace("/ns"))
         s.eio.get_session = fake_get_session
         s.eio.save_session = fake_save_session
         s._handle_eio_connect('123', 'environ')
@@ -735,6 +745,11 @@ class TestServer(unittest.TestCase):
 
     def test_disconnect_namespace(self, eio):
         s = server.Server()
+
+        class FooNamespace(namespace.Namespace):
+            pass
+
+        s.register_namespace(FooNamespace("/foo"))
         s._handle_eio_connect('123', 'environ')
         s._handle_eio_message('123', '0/foo,')
         s.disconnect('1', namespace='/foo')


### PR DESCRIPTION
This PR fixes issue #822

Accepting client connections for an unknown namespace could be problematic and hard to debug besides security issues.
In this PR new exception (**NamespaceNotFoundError**) is introduced which will prevent clients to connect with reason.