### PR TITLE
 Fix indentation in the "Rooms" docs example.

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -380,9 +380,9 @@ rooms as needed and can be moved between rooms as often as necessary.
 
 ::
 
-   @sio.event
-   def begin_chat(sid):
-      sio.enter_room(sid, 'chat_users')
+    @sio.event
+    def begin_chat(sid):
+        sio.enter_room(sid, 'chat_users')
 
     @sio.event
     def exit_chat(sid):


### PR DESCRIPTION
[The first example of the "Rooms" section of the Socket.IO Server docs](https://python-socketio.readthedocs.io/en/latest/server.html#rooms) is not indented properly.  This PR fixes the indentation.