### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/socketio/asyncio_manager.py
+++ b/src/socketio/asyncio_manager.py
@@ -26,8 +26,9 @@ class AsyncManager(BaseManager):
                     id = self._generate_ack_id(sid, callback)
                 else:
                     id = None
-                tasks.append(self.server._emit_internal(eio_sid, event, data,
-                                                        namespace, id))
+                tasks.append(asyncio.create_task(
+                    self.server._emit_internal(eio_sid, event, data,
+                                               namespace, id)))
         if tasks == []:  # pragma: no cover
             return
         await asyncio.wait(tasks)


### PR DESCRIPTION
In `emit` method of `asyncio_manager`, coroutines objects are directly passed to `asyncio.wait`, this comportment is deprecated since python 3.8 and will be removed in python 3.11, see [python doc](https://docs.python.org/3/library/asyncio-task.html#waiting-primitives) for more information.

https://github.com/miguelgrinberg/python-socketio/blob/5b9134617759a1b64adb2f9aba0974c732576cc4/src/socketio/asyncio_manager.py#L11-L33

This patch fixes that problem by adding the required `asyncio.create_task`