### PR TITLE
Report which namespaces remain unconnected

### DIFF
--- a/src/socketio/asyncio_client.py
+++ b/src/socketio/asyncio_client.py
@@ -158,10 +158,13 @@ class AsyncClient(client.Client):
                         break
             except asyncio.TimeoutError:
                 pass
-            if set(self.namespaces) != set(self.connection_namespaces):
+            unconnected = set(self.connection_namespaces) - set(self.namespaces)
+            if unconnected:
                 await self.disconnect()
                 raise exceptions.ConnectionError(
-                    'One or more namespaces failed to connect')
+                    'One or more namespaces failed to connect: %r'
+                    % (list(unconnected),)
+                )
 
         self.connected = True
 


### PR DESCRIPTION
Issue #822 causes clients previously able to connect to unknown server namespaces to fail.  The error reported is not very informative.  This PR adds the list of not-connected namespaces to the exception message.