### PR TITLE
Update msgpack_packet.py

### DIFF
--- a/src/socketio/msgpack_packet.py
+++ b/src/socketio/msgpack_packet.py
@@ -13,6 +13,6 @@ class MsgPackPacket(packet.Packet):
         """Decode a transmitted package."""
         decoded = msgpack.loads(encoded_packet)
         self.packet_type = decoded['type']
-        self.data = decoded['data']
+        self.data = decoded.get('data')
         self.id = decoded.get('id')
         self.namespace = decoded['nsp']


### PR DESCRIPTION
Based on the official documentation payload is optional. 

Problem: This caused issues when using python-socketio together with other implementations.

Currently:
`self.data = decoded['data']`

Should be:
`self.data = decoded.get('data')`

Reference:
https://github.com/miguelgrinberg/python-socketio/blob/d556a0ec4de5ef2ca21626ce8b41d68126ec3605/src/socketio/msgpack_packet.py#L16

Documentation: 
https://github.com/socketio/socket.io-protocol#packet-format