### PR TITLE
(seatedscribe) Let reconnect use wait parameters

### DIFF
--- a/src/socketio/asyncio_client.py
+++ b/src/socketio/asyncio_client.py
@@ -122,6 +122,8 @@ class AsyncClient(client.Client):
         self.connection_transports = transports
         self.connection_namespaces = namespaces
         self.socketio_path = socketio_path
+        self.wait = wait
+        self.wait_timeout = wait_timeout
 
         if namespaces is None:
             namespaces = list(set(self.handlers.keys()).union(
@@ -479,7 +481,9 @@ class AsyncClient(client.Client):
                                    auth=self.connection_auth,
                                    transports=self.connection_transports,
                                    namespaces=self.connection_namespaces,
-                                   socketio_path=self.socketio_path)
+                                   socketio_path=self.socketio_path,
+                                   wait=self.wait,
+                                   wait_timeout = self.wait_timeout)
             except (exceptions.ConnectionError, ValueError):
                 pass
             else:

--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -311,6 +311,8 @@ class Client(object):
         self.connection_transports = transports
         self.connection_namespaces = namespaces
         self.socketio_path = socketio_path
+        self.wait = wait
+        self.wait_timeout = wait_timeout
 
         if namespaces is None:
             namespaces = list(set(self.handlers.keys()).union(
@@ -662,7 +664,9 @@ class Client(object):
                              auth=self.connection_auth,
                              transports=self.connection_transports,
                              namespaces=self.connection_namespaces,
-                             socketio_path=self.socketio_path)
+                             socketio_path=self.socketio_path,
+                             wait=self.wait,
+                             wait_timeout=self.wait_timeout)
             except (exceptions.ConnectionError, ValueError):
                 pass
             else:


### PR DESCRIPTION
If a client is successfully connected to a server which is later pulled down for a few seconds, what happens at the reconnection stage? 
In my case the connected flag needed to be true as soon as the 'connect' event is thrown, not after one second (default implicit value)

So I propose this PR to put coherence between connect and reconnect algos, hope it is helpful!