### PR TITLE
feat: pass manager kwargs from namespace

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -577,6 +577,16 @@ The RabbitMQ queue is configured through the
     mgr = socketio.AsyncAioPikaManager('amqp://')
     sio = socketio.AsyncServer(client_manager=mgr)
 
+Ignore the queue
+~~~~~~~~~~~~~~~~
+
+With the message queue config, by default when emiting a message, 
+all server instances are recieving it and redistribute it, if the specific client is connected. 
+To ignore this queue you can use ignore_queue parameter. ::
+
+    # ignore queue 
+    sio.emit("my event", data={'foo':'bar'}, room='my room', ignore_queue=True)
+
 Emitting from external processes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/socketio/asyncio_manager.py
+++ b/src/socketio/asyncio_manager.py
@@ -9,7 +9,7 @@ class AsyncManager(BaseManager):
         return self.is_connected(sid, namespace)
 
     async def emit(self, event, data, namespace, room=None, skip_sid=None,
-                   callback=None, **kwargs):
+                   callback=None):
         """Emit a message to a single client, a room, or all the clients
         connected to the namespace.
 

--- a/src/socketio/asyncio_namespace.py
+++ b/src/socketio/asyncio_namespace.py
@@ -42,7 +42,7 @@ class AsyncNamespace(namespace.Namespace):
             return ret
 
     async def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-                   namespace=None, callback=None, **kwargs):
+                   namespace=None, callback=None, ignore_queue=False):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -54,7 +54,8 @@ class AsyncNamespace(namespace.Namespace):
         return await self.server.emit(event, data=data, to=to, room=room,
                                       skip_sid=skip_sid,
                                       namespace=namespace or self.namespace,
-                                      callback=callback, **kwargs)
+                                      callback=callback, 
+                                      ignore_queue=ignore_queue)
 
     async def send(self, data, to=None, room=None, skip_sid=None,
                    namespace=None, callback=None):

--- a/src/socketio/asyncio_namespace.py
+++ b/src/socketio/asyncio_namespace.py
@@ -42,7 +42,7 @@ class AsyncNamespace(namespace.Namespace):
             return ret
 
     async def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-                   namespace=None, callback=None,**kwargs):
+                   namespace=None, callback=None, **kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -54,7 +54,7 @@ class AsyncNamespace(namespace.Namespace):
         return await self.server.emit(event, data=data, to=to, room=room,
                                       skip_sid=skip_sid,
                                       namespace=namespace or self.namespace,
-                                      callback=callback,**kwargs)
+                                      callback=callback, **kwargs)
 
     async def send(self, data, to=None, room=None, skip_sid=None,
                    namespace=None, callback=None):

--- a/src/socketio/asyncio_namespace.py
+++ b/src/socketio/asyncio_namespace.py
@@ -42,7 +42,7 @@ class AsyncNamespace(namespace.Namespace):
             return ret
 
     async def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-                   namespace=None, callback=None):
+                   namespace=None, callback=None,**kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -54,7 +54,7 @@ class AsyncNamespace(namespace.Namespace):
         return await self.server.emit(event, data=data, to=to, room=room,
                                       skip_sid=skip_sid,
                                       namespace=namespace or self.namespace,
-                                      callback=callback)
+                                      callback=callback,**kwargs)
 
     async def send(self, data, to=None, room=None, skip_sid=None,
                    namespace=None, callback=None):

--- a/src/socketio/asyncio_pubsub_manager.py
+++ b/src/socketio/asyncio_pubsub_manager.py
@@ -38,7 +38,7 @@ class AsyncPubSubManager(AsyncManager):
         self._get_logger().info(self.name + ' backend initialized.')
 
     async def emit(self, event, data, namespace=None, room=None, skip_sid=None,
-                   callback=None, **kwargs):
+                   callback=None, ignore_queue=False):
         """Emit a message to a single client, a room, or all the clients
         connected to the namespace.
 
@@ -49,7 +49,7 @@ class AsyncPubSubManager(AsyncManager):
 
         Note: this method is a coroutine.
         """
-        if kwargs.get('ignore_queue'):
+        if ignore_queue:
             return await super().emit(
                 event, data, namespace=namespace, room=room, skip_sid=skip_sid,
                 callback=callback)

--- a/src/socketio/asyncio_server.py
+++ b/src/socketio/asyncio_server.py
@@ -117,7 +117,7 @@ class AsyncServer(server.Server):
         self.eio.attach(app, socketio_path)
 
     async def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-                   namespace=None, callback=None, **kwargs):
+                   namespace=None, callback=None, ignore_queue=False):
         """Emit a custom event to one or more connected clients.
 
         :param event: The event name. It can be any string. The event names
@@ -167,7 +167,7 @@ class AsyncServer(server.Server):
                          room or 'all', namespace)
         await self.manager.emit(event, data, namespace, room=room,
                                 skip_sid=skip_sid, callback=callback,
-                                **kwargs)
+                                ignore_queue=False)
 
     async def send(self, data, to=None, room=None, skip_sid=None,
                    namespace=None, callback=None, **kwargs):

--- a/src/socketio/namespace.py
+++ b/src/socketio/namespace.py
@@ -38,7 +38,7 @@ class Namespace(BaseNamespace):
         self.server = server
 
     def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-             namespace=None, callback=None,**kwargs):
+             namespace=None, callback=None, **kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -48,7 +48,7 @@ class Namespace(BaseNamespace):
         return self.server.emit(event, data=data, to=to, room=room,
                                 skip_sid=skip_sid,
                                 namespace=namespace or self.namespace,
-                                callback=callback,**kwargs)
+                                callback=callback, **kwargs)
 
     def send(self, data, to=None, room=None, skip_sid=None, namespace=None,
              callback=None):

--- a/src/socketio/namespace.py
+++ b/src/socketio/namespace.py
@@ -38,7 +38,7 @@ class Namespace(BaseNamespace):
         self.server = server
 
     def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-             namespace=None, callback=None, **kwargs):
+             namespace=None, callback=None, ignore_queue=False):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -48,7 +48,8 @@ class Namespace(BaseNamespace):
         return self.server.emit(event, data=data, to=to, room=room,
                                 skip_sid=skip_sid,
                                 namespace=namespace or self.namespace,
-                                callback=callback, **kwargs)
+                                callback=callback,
+                                ignore_queue=ignore_queue)
 
     def send(self, data, to=None, room=None, skip_sid=None, namespace=None,
              callback=None):

--- a/src/socketio/namespace.py
+++ b/src/socketio/namespace.py
@@ -38,7 +38,7 @@ class Namespace(BaseNamespace):
         self.server = server
 
     def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-             namespace=None, callback=None):
+             namespace=None, callback=None,**kwargs):
         """Emit a custom event to one or more connected clients.
 
         The only difference with the :func:`socketio.Server.emit` method is
@@ -48,7 +48,7 @@ class Namespace(BaseNamespace):
         return self.server.emit(event, data=data, to=to, room=room,
                                 skip_sid=skip_sid,
                                 namespace=namespace or self.namespace,
-                                callback=callback)
+                                callback=callback,**kwargs)
 
     def send(self, data, to=None, room=None, skip_sid=None, namespace=None,
              callback=None):

--- a/src/socketio/pubsub_manager.py
+++ b/src/socketio/pubsub_manager.py
@@ -37,7 +37,7 @@ class PubSubManager(BaseManager):
         self._get_logger().info(self.name + ' backend initialized.')
 
     def emit(self, event, data, namespace=None, room=None, skip_sid=None,
-             callback=None, **kwargs):
+             callback=None, ignore_queue=False):
         """Emit a message to a single client, a room, or all the clients
         connected to the namespace.
 
@@ -46,7 +46,7 @@ class PubSubManager(BaseManager):
 
         The parameters are the same as in :meth:`.Server.emit`.
         """
-        if kwargs.get('ignore_queue'):
+        if ignore_queue:
             return super(PubSubManager, self).emit(
                 event, data, namespace=namespace, room=room, skip_sid=skip_sid,
                 callback=callback)

--- a/src/socketio/server.py
+++ b/src/socketio/server.py
@@ -269,7 +269,7 @@ class Server(object):
             namespace_handler
 
     def emit(self, event, data=None, to=None, room=None, skip_sid=None,
-             namespace=None, callback=None, **kwargs):
+             namespace=None, callback=None, ignore_queue=False):
         """Emit a custom event to one or more connected clients.
 
         :param event: The event name. It can be any string. The event names
@@ -317,7 +317,7 @@ class Server(object):
         self.logger.info('emitting event "%s" to %s [%s]', event,
                          room or 'all', namespace)
         self.manager.emit(event, data, namespace, room=room,
-                          skip_sid=skip_sid, callback=callback, **kwargs)
+                          skip_sid=skip_sid, callback=callback, ignore_queue=ignore_queue)
 
     def send(self, data, to=None, room=None, skip_sid=None, namespace=None,
              callback=None, **kwargs):


### PR DESCRIPTION
# WHY
I need to pass `ignore_queue` from namespace emit call. 
# WHAT 
Pass kwargs from namespace emit to server emit