### PR TITLE
Explicitly create tasks for coroutines before waiting on them

### DIFF
--- a/socketio/asyncio_manager.py
+++ b/socketio/asyncio_manager.py
@@ -26,8 +26,8 @@ class AsyncManager(BaseManager):
                     id = self._generate_ack_id(sid, namespace, callback)
                 else:
                     id = None
-                tasks.append(self.server._emit_internal(sid, event, data,
-                                                        namespace, id))
+                tasks.append(asyncio.create_task(self.server._emit_internal(sid, event, data,
+                                                                            namespace, id)))
         if tasks == []:  # pragma: no cover
             return
         await asyncio.wait(tasks)


### PR DESCRIPTION
Passing coroutines directly is deprecated for python 3.11.
