### PR TITLE
Update `ping_timeout` docs to accord with engineio behavior

### DIFF
--- a/src/socketio/async_server.py
+++ b/src/socketio/async_server.py
@@ -64,7 +64,7 @@ class AsyncServer(base_server.BaseServer):
                           is a grace period added by the server.
     :param ping_timeout: The time in seconds that the client waits for the
                          server to respond before disconnecting. The default
-                         is 5 seconds.
+                         is 20 seconds.
     :param max_http_buffer_size: The maximum size of a message when using the
                                  polling transport. The default is 1,000,000
                                  bytes.

--- a/src/socketio/server.py
+++ b/src/socketio/server.py
@@ -73,7 +73,7 @@ class Server(base_server.BaseServer):
                           is a grace period added by the server.
     :param ping_timeout: The time in seconds that the client waits for the
                          server to respond before disconnecting. The default
-                         is 5 seconds.
+                         is 20 seconds.
     :param max_http_buffer_size: The maximum size of a message when using the
                                  polling transport. The default is 1,000,000
                                  bytes.


### PR DESCRIPTION
The stated default of `ping_timeout` is incorrect. This PR updates the docstring so that it accords with what is in engineio.

The docstring says the default is 5s when it is actually 20s, as documented by engineio [here](https://github.com/miguelgrinberg/python-engineio/blob/5c996bec85d864526fe41569438a6e15e4a53123/src/engineio/async_server.py#L30-L32) and [here](https://github.com/miguelgrinberg/python-engineio/blob/5c996bec85d864526fe41569438a6e15e4a53123/src/engineio/server.py#L31-L33)

Those docstrings correctly reflect the defaults, which are defined in the constructor [here](https://github.com/miguelgrinberg/python-engineio/blob/5c996bec85d864526fe41569438a6e15e4a53123/src/engineio/base_server.py#L22).