### PR TITLE
Fix bug with packet.id equivalent to zero; check if message id is not None instead of boolean casting

### DIFF
--- a/src/socketio/packet.py
+++ b/src/socketio/packet.py
@@ -185,6 +185,6 @@ class Packet(object):
             'data': self.data,
             'nsp': self.namespace,
         }
-        if self.id:
+        if self.id is not None:
             d['id'] = self.id
         return d


### PR DESCRIPTION
Just check the commit