### PR TITLE
Added 'add_trailing_slash' option to WSGIApp and ASGIApp init definitions to be in concordance with this same option being added to engineio

### DIFF
--- a/src/socketio/asgi.py
+++ b/src/socketio/asgi.py
@@ -40,8 +40,8 @@ class ASGIApp(engineio.ASGIApp):  # pragma: no cover
     """
     def __init__(self, socketio_server, other_asgi_app=None,
                  static_files=None, socketio_path='socket.io',
-                 on_startup=None, on_shutdown=None):
+                 on_startup=None, on_shutdown=None, add_trailing_slash=True):
         super().__init__(socketio_server, other_asgi_app,
                          static_files=static_files,
                          engineio_path=socketio_path, on_startup=on_startup,
-                         on_shutdown=on_shutdown)
+                         on_shutdown=on_shutdown, add_trailing_slash=add_trailing_slash)

--- a/src/socketio/middleware.py
+++ b/src/socketio/middleware.py
@@ -28,9 +28,9 @@ class WSGIApp(engineio.WSGIApp):
         eventlet.wsgi.server(eventlet.listen(('', 8000)), app)
     """
     def __init__(self, socketio_app, wsgi_app=None, static_files=None,
-                 socketio_path='socket.io'):
+                 socketio_path='socket.io', add_trailing_slash=True):
         super().__init__(socketio_app, wsgi_app, static_files=static_files,
-                         engineio_path=socketio_path)
+                         engineio_path=socketio_path, add_trailing_slash=add_trailing_slash)
 
 
 class Middleware(WSGIApp):


### PR DESCRIPTION
This is necessary for [this](https://github.com/miguelgrinberg/python-engineio/pull/360) pull request at python-engineio I made to work when creating an ASGIApp or a WSGIApp.