### PR TITLE
Prevent multiple tasks for reconnection

### DIFF
--- a/src/socketio/async_client.py
+++ b/src/socketio/async_client.py
@@ -578,7 +578,7 @@ class AsyncClient(base_client.BaseClient):
         self.callbacks = {}
         self._binary_packet = None
         self.sid = None
-        if will_reconnect:
+        if will_reconnect and not self._reconnect_task:
             self._reconnect_task = self.start_background_task(
                 self._handle_reconnect)
 

--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -534,7 +534,7 @@ class Client(base_client.BaseClient):
         self.callbacks = {}
         self._binary_packet = None
         self.sid = None
-        if will_reconnect:
+        if will_reconnect and not self._reconnect_task:
             self._reconnect_task = self.start_background_task(
                 self._handle_reconnect)
 


### PR DESCRIPTION
As discussed here.

https://github.com/miguelgrinberg/python-socketio/discussions/1367

In certain scenarios, this library creates multiple reconnection tasks.

A check is added to make sure that reconnection task starts only when

this task is not running.