### PR TITLE
Introducing python-socketio Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 python-socketio
 ===============
 
-[![Build status](https://github.com/miguelgrinberg/python-socketio/workflows/build/badge.svg)](https://github.com/miguelgrinberg/python-socketio/actions) [![codecov](https://codecov.io/gh/miguelgrinberg/python-socketio/branch/main/graph/badge.svg)](https://codecov.io/gh/miguelgrinberg/python-socketio)
+[![Build status](https://github.com/miguelgrinberg/python-socketio/workflows/build/badge.svg)](https://github.com/miguelgrinberg/python-socketio/actions) [![codecov](https://codecov.io/gh/miguelgrinberg/python-socketio/branch/main/graph/badge.svg)](https://codecov.io/gh/miguelgrinberg/python-socketio) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20python--socketio%20Guru-006BFF)](https://gurubase.io/g/python-socketio)
 
 Python implementation of the `Socket.IO` realtime client and server.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [python-socketio Guru](https://gurubase.io/g/python-socketio) to Gurubase. python-socketio Guru uses the data from this repo and data from the [docs](http://python-socketio.readthedocs.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "python-socketio Guru", which highlights that python-socketio now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable python-socketio Guru in Gurubase, just let me know that's totally fine.
