### PR TITLE
fix AsyncClient::wait unexpected return after success reconnect

### DIFF
--- a/src/socketio/async_client.py
+++ b/src/socketio/async_client.py
@@ -188,9 +188,10 @@ class AsyncClient(base_client.BaseClient):
         while True:
             await self.eio.wait()
             await self.sleep(1)  # give the reconnect task time to start up
-            if self.eio.state == 'connected': # connected during await self.sleep(1)
-                continue
             if not self._reconnect_task:
+                if self.eio.state == 'connected':  # pragma: no cover
+                    # connected while sleeping above
+                    continue
                 break
             await self._reconnect_task
             if self.eio.state != 'connected':

--- a/src/socketio/async_client.py
+++ b/src/socketio/async_client.py
@@ -188,7 +188,7 @@ class AsyncClient(base_client.BaseClient):
         while True:
             await self.eio.wait()
             await self.sleep(1)  # give the reconnect task time to start up
-            if not self._reconnect_task:
+            if not self._reconnect_task and self.eio.state != 'connected':
                 break
             await self._reconnect_task
             if self.eio.state != 'connected':

--- a/src/socketio/async_client.py
+++ b/src/socketio/async_client.py
@@ -188,7 +188,9 @@ class AsyncClient(base_client.BaseClient):
         while True:
             await self.eio.wait()
             await self.sleep(1)  # give the reconnect task time to start up
-            if not self._reconnect_task and self.eio.state != 'connected':
+            if self.eio.state == 'connected': # connected during await self.sleep(1)
+                continue
+            if not self._reconnect_task:
                 break
             await self._reconnect_task
             if self.eio.state != 'connected':

--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -179,10 +179,13 @@ class Client(base_client.BaseClient):
         while True:
             self.eio.wait()
             self.sleep(1)  # give the reconnect task time to start up
-            if self.eio.state != 'connected': # reconnect task finished while `self.sleep(1)` was executing
-                continue
             if not self._reconnect_task:
-                break
+                if self.eio.state == 'connected':  # pragma: no cover
+                    # connected while sleeping above
+                    continue
+                else:
+                    # the reconnect task gave up
+                    break
             self._reconnect_task.join()
             if self.eio.state != 'connected':
                 break

--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -179,6 +179,8 @@ class Client(base_client.BaseClient):
         while True:
             self.eio.wait()
             self.sleep(1)  # give the reconnect task time to start up
+            if self.eio.state != 'connected': # reconnect task finished while `self.sleep(1)` was executing
+                continue
             if not self._reconnect_task:
                 break
             self._reconnect_task.join()


### PR DESCRIPTION
AsyncClient::wait use sleep(1) call to wait to start reconnect task. Sometimes reconnect is faster then 1 second, and wait returns while connection to server is established.

Added one check to method to avoid this situation