### PR TITLE
server.py: teeny docstring typo fix

### DIFF
--- a/src/socketio/server.py
+++ b/src/socketio/server.py
@@ -87,7 +87,7 @@ class Server(base_server.BaseServer):
                                   is greater than this value. The default is
                                   1024 bytes.
     :param cookie: If set to a string, it is the name of the HTTP cookie the
-                   server sends back tot he client containing the client
+                   server sends back to the client containing the client
                    session id. If set to a dictionary, the ``'name'`` key
                    contains the cookie name and other keys define cookie
                    attributes, where the value of each attribute can be a


### PR DESCRIPTION
Noticed while perusing the documentation, so submitting a micropatch.