### PR TITLE
Add the reason argument for async_admin when socket disconnect

### DIFF
--- a/src/socketio/admin.py
+++ b/src/socketio/admin.py
@@ -216,12 +216,12 @@ class InstrumentedServer:
         ), namespace=self.admin_namespace)
         return sid
 
-    def _disconnect(self, sid, namespace, **kwargs):
+    def _disconnect(self, sid, namespace, reason, **kwargs):
         del self.sio.manager._timestamps[sid]
         self.sio.emit('socket_disconnected', (
             namespace,
             sid,
-            'N/A',
+            reason or 'N/A',
             datetime.utcnow().isoformat() + 'Z',
         ), namespace=self.admin_namespace)
         return self.sio.manager.__disconnect(sid, namespace, **kwargs)
@@ -303,9 +303,9 @@ class InstrumentedServer:
         self.event_buffer.push('rawConnection')
         return self.sio._handle_eio_connect(eio_sid, environ)
 
-    def _handle_eio_disconnect(self, eio_sid):
+    def _handle_eio_disconnect(self, eio_sid, reason):
         self.event_buffer.push('rawDisconnection')
-        return self.sio._handle_eio_disconnect(eio_sid)
+        return self.sio._handle_eio_disconnect(eio_sid, reason)
 
     def _eio_http_response(self, packets=None, headers=None, jsonp_index=None):
         ret = self.sio.eio.__ok(packets=packets, headers=headers,

--- a/src/socketio/async_admin.py
+++ b/src/socketio/async_admin.py
@@ -204,12 +204,12 @@ class InstrumentedAsyncServer:
         ), namespace=self.admin_namespace)
         return sid
 
-    async def _disconnect(self, sid, namespace, **kwargs):
+    async def _disconnect(self, sid, namespace, reason, **kwargs):
         del self.sio.manager._timestamps[sid]
         await self.sio.emit('socket_disconnected', (
             namespace,
             sid,
-            'N/A',
+            reason or 'N/A',
             datetime.utcnow().isoformat() + 'Z',
         ), namespace=self.admin_namespace)
         return await self.sio.manager.__disconnect(sid, namespace, **kwargs)
@@ -292,9 +292,9 @@ class InstrumentedAsyncServer:
         self.event_buffer.push('rawConnection')
         return await self.sio._handle_eio_connect(eio_sid, environ)
 
-    async def _handle_eio_disconnect(self, eio_sid):
+    async def _handle_eio_disconnect(self, eio_sid, reason):
         self.event_buffer.push('rawDisconnection')
-        return await self.sio._handle_eio_disconnect(eio_sid)
+        return await self.sio._handle_eio_disconnect(eio_sid, reason)
 
     def _eio_http_response(self, packets=None, headers=None, jsonp_index=None):
         ret = self.sio.eio.__ok(packets=packets, headers=headers,

--- a/src/socketio/async_server.py
+++ b/src/socketio/async_server.py
@@ -585,7 +585,7 @@ class AsyncServer(base_server.BaseServer):
         self.manager.pre_disconnect(sid, namespace=namespace)
         await self._trigger_event('disconnect', namespace, sid,
                                   reason or self.reason.CLIENT_DISCONNECT)
-        await self.manager.disconnect(sid, namespace, reason=reason or self.reason.CLIENT_DISCONNECT, ignore_queue=True)
+        await self.manager.disconnect(sid, namespace, ignore_queue=True)
 
     async def _handle_event(self, eio_sid, namespace, id, data):
         """Handle an incoming client event."""

--- a/src/socketio/async_server.py
+++ b/src/socketio/async_server.py
@@ -585,7 +585,7 @@ class AsyncServer(base_server.BaseServer):
         self.manager.pre_disconnect(sid, namespace=namespace)
         await self._trigger_event('disconnect', namespace, sid,
                                   reason or self.reason.CLIENT_DISCONNECT)
-        await self.manager.disconnect(sid, namespace, ignore_queue=True)
+        await self.manager.disconnect(sid, namespace, reason=reason or self.reason.CLIENT_DISCONNECT, ignore_queue=True)
 
     async def _handle_event(self, eio_sid, namespace, id, data):
         """Handle an incoming client event."""


### PR DESCRIPTION
Hi,

I am using python-socketio with an Admin UI and noticed that the disconnect reason is not being displayed. I have made some modifications to address this issue. Could you please review my pull request?

Thank you for your time and consideration!