### PR TITLE
docs: fix broken gevent url

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -189,7 +189,7 @@ Server Features
 - Can be hosted on any `WSGI <https://wsgi.readthedocs.io/en/latest/index.html>`_ or
   `ASGI <https://asgi.readthedocs.io/en/latest/>`_ web server including
   `Gunicorn <https://gunicorn.org/>`_, `Uvicorn <https://github.com/encode/uvicorn>`_,
-  `eventlet <http://eventlet.net/>`_ and `gevent <http://gevent.org>`_.
+  `eventlet <http://eventlet.net/>`_ and `gevent <http://www.gevent.org>`_.
 - Can be integrated with WSGI applications written in frameworks such as Flask, Django,
   etc.
 - Can be integrated with `aiohttp <http://aiohttp.readthedocs.io/>`_,

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -838,7 +838,7 @@ Gevent
 
 When a multi-threaded web server is unable to satisfy the concurrency and
 scalability requirements of the application, an option to try is
-`Gevent <http://gevent.org>`_. Gevent is a coroutine-based concurrency library
+`Gevent <http://www.gevent.org>`_. Gevent is a coroutine-based concurrency library
 based on greenlets, which are significantly lighter than threads.
 
 Instances of class ``socketio.Server`` will automatically use Gevent if the


### PR DESCRIPTION
The gevent's website base URL ([gevent.org](http://gevent.org)) is not working. 

![{FB97528C-9D7F-4D85-995C-E37B343D5D19}](https://github.com/user-attachments/assets/a171c7e9-34cf-4a46-9232-c7573f03b712)

This pull request replaces it with [www.gevent.org](http://www.gevent.org), which works correctly.