### PR TITLE
Preserve exception context in Client.connect

### DIFF
--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -156,7 +156,7 @@ class Client(base_client.BaseClient):
                 self._handle_reconnect()
                 if self.eio.state == 'connected':
                     return
-            raise exceptions.ConnectionError(exc.args[0]) from None
+            raise exceptions.ConnectionError(exc.args[0]) from exc
 
         if wait:
             while self._connect_event.wait(timeout=wait_timeout):


### PR DESCRIPTION
Currently, connection errors give a stack trace like this:

```
Traceback (most recent call last):
  File "...", line 37, in <module>
    main()
  File "...", line 19, in main
    client.connect(args.url, namespace=args.namespace, transports=["websocket"])
  File ".../socketio/simple_client.py", line 82, in connect
    self.client.connect(url, headers=headers, auth=auth,
  File ".../socketio/client.py", line 159, in connect
    raise exceptions.ConnectionError(exc.args[0]) from None
socketio.exceptions.ConnectionError: Connection error
```

This discards the stack trace of `exc`, which can be useful for figuring out what the connection error was. Raising `from exc` preserves this:

```
Traceback (most recent call last):
  File ".../engineio/client.py", line 332, in _connect_websocket
    ws = websocket.create_connection(
  File ".../websocket/_core.py", line 646, in create_connection
    websock.connect(url, **options)
  File ".../websocket/_core.py", line 256, in connect
    self.sock, addrs = connect(
  File ".../websocket/_http.py", line 145, in connect
    sock = _open_socket(addrinfo_list, options.sockopt, options.timeout)
  File ".../websocket/_http.py", line 222, in _open_socket
    raise error
  File ".../websocket/_http.py", line 209, in _open_socket
    sock.connect(address)
TimeoutError: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../socketio/client.py", line 147, in connect
    self.eio.connect(real_url, headers=real_headers,
  File ".../engineio/client.py", line 95, in connect
    return getattr(self, '_connect_' + self.transports[0])(
  File ".../engineio/client.py", line 340, in _connect_websocket
    raise exceptions.ConnectionError('Connection error')
engineio.exceptions.ConnectionError: Connection error

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "...", line 37, in <module>
    main()
  File "...", line 19, in main
    client.connect(args.url, namespace=args.namespace, transports=["websocket"])
  File ".../socketio/simple_client.py", line 82, in connect
    self.client.connect(url, headers=headers, auth=auth,
  File ".../socketio/client.py", line 159, in connect
    raise exceptions.ConnectionError(exc.args[0]) from exc
socketio.exceptions.ConnectionError: Connection error
```