### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "python-socketio"
 version = "5.13.1.dev0"
+license = {text = "MIT"}
 authors = [
     { name = "Miguel Grinberg", email = "miguel.grinberg@gmail.com" },
 ]
@@ -9,7 +10,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
This is in preparation for PEP 639 license expressions. Setuptools `v77` recently added full support for it. However that requires Python `>=3.9`, i.e. dropping support for `3.8` first.

With this PR all that's needed later is
```diff
-license = {text = "MIT"}
+license = "MIT"
 ...
 [build-system]
-requires = ["setuptools>=61.2"]
+requires = ["setuptools>=77.0"]
```
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files