### PR TITLE
Fix `eio.session` example on async server

### DIFF
--- a/src/socketio/async_server.py
+++ b/src/socketio/async_server.py
@@ -373,15 +373,15 @@ class AsyncServer(base_server.BaseServer):
         context manager block are saved back to the session. Example usage::
 
             @eio.on('connect')
-            def on_connect(sid, environ):
+            async def on_connect(sid, environ):
                 username = authenticate_user(environ)
                 if not username:
                     return False
-                with eio.session(sid) as session:
+                async with eio.session(sid) as session:
                     session['username'] = username
 
             @eio.on('message')
-            def on_message(sid, msg):
+            async def on_message(sid, msg):
                 async with eio.session(sid) as session:
                     print('received message from ', session['username'])
         """


### PR DESCRIPTION
Added missing `async` for some usages.