### PR TITLE
Keep track of which namespaces failed to connect

### DIFF
--- a/src/socketio/base_client.py
+++ b/src/socketio/base_client.py
@@ -93,6 +93,7 @@ class BaseClient:
 
         self.connected = False  #: Indicates if the client is connected or not.
         self.namespaces = {}  #: set of connected namespaces.
+        self.failed_namespaces = []
         self.handlers = {}
         self.namespace_handlers = {}
         self.callbacks = {}


### PR DESCRIPTION
This change adds the name(s) of the failed namespaces to the error message included with the raised connection exception. Also, it indirectly optimizes the wait for namespaces in the connection method, by returning after all the namespaces are known to have succeeded or failed, instead of waiting until the wait timeout.