### PR TITLE
SimpleClient: type mismatch for `SimpleClient.transport()`

### DIFF
--- a/src/socketio/simple_client.py
+++ b/src/socketio/simple_client.py
@@ -103,7 +103,7 @@ class SimpleClient:
         The transport is returned as a string and can be one of ``polling``
         and ``websocket``.
         """
-        return self.client.transport if self.client else ''
+        return self.client.transport if self.client else lambda: ''
 
     def emit(self, event, data=None):
         """Emit an event to the server.


### PR DESCRIPTION
Normally, `SimpleClient.transport` has signature `() -> str`. However, if `SimpleClient.connect()` is not called `SimpleClient.transport` is simply a `str` (not a function).

I came across this as this was confusing the Pylance type checker.

My proposed fix ensures reasonable behaviour by always making `SimpleClient.transport` a function. It shouldn't break anything important since `SimpleClient.transport` is meaningless before `connect` is called anyway. However, this is not a strictly backwards-compatible change.