### PR TITLE
Add support for unix-sock protocol

### DIFF
--- a/src/socketio/async_redis_manager.py
+++ b/src/socketio/async_redis_manager.py
@@ -70,7 +70,7 @@ class AsyncRedisManager(AsyncPubSubManager):  # pragma: no cover
     def _get_redis_module_and_error(self):
         parsed_url = urlparse(self.redis_url)
         schema = parsed_url.scheme.split('+', 1)[0].lower()
-        if schema == 'redis':
+        if schema in ['redis', 'unix']:
             if aioredis is None or RedisError is None:
                 raise RuntimeError('Redis package is not installed '
                                    '(Run "pip install redis" '

--- a/src/socketio/redis_manager.py
+++ b/src/socketio/redis_manager.py
@@ -108,7 +108,7 @@ class RedisManager(PubSubManager):  # pragma: no cover
     def _get_redis_module_and_error(self):
         parsed_url = urlparse(self.redis_url)
         schema = parsed_url.scheme.split('+', 1)[0].lower()
-        if schema == 'redis':
+        if schema in ['redis', 'unix']:
             if redis is None or RedisError is None:
                 raise RuntimeError('Redis package is not installed '
                                    '(Run "pip install redis" '


### PR DESCRIPTION
Python Redis supports unix socket url, so this should also be supported.