### PR TITLE
Restore binary message support in message queue setups (Fixes #1508)

### DIFF
--- a/tests/async/test_pubsub_manager.py
+++ b/tests/async/test_pubsub_manager.py
@@ -57,7 +57,38 @@ class TestAsyncPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
+                'namespace': '/',
+                'room': None,
+                'skip_sid': None,
+                'callback': None,
+                'host_id': '123456',
+            }
+        )
+
+    async def test_emit_binary(self):
+        await self.pm.emit('foo', b'bar')
+        self.pm._publish.assert_awaited_once_with(
+            {
+                'method': 'emit',
+                'event': 'foo',
+                'binary': True,
+                'data': [{'_placeholder': True, 'num': 0}, 'YmFy'],
+                'namespace': '/',
+                'room': None,
+                'skip_sid': None,
+                'callback': None,
+                'host_id': '123456',
+            }
+        )
+        await self.pm.emit('foo', {'foo': b'bar'})
+        self.pm._publish.assert_awaited_with(
+            {
+                'method': 'emit',
+                'event': 'foo',
+                'binary': True,
+                'data': [{'foo': {'_placeholder': True, 'num': 0}}, 'YmFy'],
                 'namespace': '/',
                 'room': None,
                 'skip_sid': None,
@@ -73,6 +104,7 @@ class TestAsyncPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/',
                 'room': sid,
@@ -88,6 +120,7 @@ class TestAsyncPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/baz',
                 'room': None,
@@ -103,6 +136,7 @@ class TestAsyncPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/',
                 'room': 'baz',
@@ -118,6 +152,7 @@ class TestAsyncPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/',
                 'room': None,
@@ -136,6 +171,7 @@ class TestAsyncPubSubManager:
                 {
                     'method': 'emit',
                     'event': 'foo',
+                    'binary': False,
                     'data': 'bar',
                     'namespace': '/',
                     'room': 'baz',
@@ -235,6 +271,37 @@ class TestAsyncPubSubManager:
             super_emit.assert_awaited_once_with(
                 'foo',
                 'bar',
+                namespace=None,
+                room=None,
+                skip_sid=None,
+                callback=None,
+            )
+
+    async def test_handle_emit_binary(self):
+        with mock.patch.object(
+            async_manager.AsyncManager, 'emit'
+        ) as super_emit:
+            await self.pm._handle_emit({
+                'event': 'foo',
+                'binary': True,
+                'data': [{'_placeholder': True, 'num': 0}, 'YmFy'],
+            })
+            super_emit.assert_awaited_once_with(
+                'foo',
+                b'bar',
+                namespace=None,
+                room=None,
+                skip_sid=None,
+                callback=None,
+            )
+            await self.pm._handle_emit({
+                'event': 'foo',
+                'binary': True,
+                'data': [{'foo': {'_placeholder': True, 'num': 0}}, 'YmFy'],
+            })
+            super_emit.assert_awaited_with(
+                'foo',
+                {'foo': b'bar'},
                 namespace=None,
                 room=None,
                 skip_sid=None,

--- a/tests/common/test_packet.py
+++ b/tests/common/test_packet.py
@@ -266,16 +266,24 @@ class TestPacket:
         assert pkt.data["a"] == "0123456789-"
         assert pkt.attachment_count == 0
 
+    def test_deconstruct_binary(self):
+        datas = [b'foo', [b'foo', b'bar'], ['foo', b'bar'], {'foo': b'bar'},
+                 {'foo': 'bar', 'baz': b'qux'}, {'foo': [b'bar']}]
+        for data in datas:
+            bdata, attachments = packet.Packet.deconstruct_binary(data)
+            rdata = packet.Packet.reconstruct_binary(bdata, attachments)
+            assert data == rdata
+
     def test_data_is_binary_list(self):
         pkt = packet.Packet()
-        assert not pkt._data_is_binary(['foo'])
-        assert not pkt._data_is_binary([])
-        assert pkt._data_is_binary([b'foo'])
-        assert pkt._data_is_binary(['foo', b'bar'])
+        assert not pkt.data_is_binary(['foo'])
+        assert not pkt.data_is_binary([])
+        assert pkt.data_is_binary([b'foo'])
+        assert pkt.data_is_binary(['foo', b'bar'])
 
     def test_data_is_binary_dict(self):
         pkt = packet.Packet()
-        assert not pkt._data_is_binary({'a': 'foo'})
-        assert not pkt._data_is_binary({})
-        assert pkt._data_is_binary({'a': b'foo'})
-        assert pkt._data_is_binary({'a': 'foo', 'b': b'bar'})
+        assert not pkt.data_is_binary({'a': 'foo'})
+        assert not pkt.data_is_binary({})
+        assert pkt.data_is_binary({'a': b'foo'})
+        assert pkt.data_is_binary({'a': 'foo', 'b': b'bar'})

--- a/tests/common/test_pubsub_manager.py
+++ b/tests/common/test_pubsub_manager.py
@@ -69,7 +69,38 @@ class TestPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
+                'namespace': '/',
+                'room': None,
+                'skip_sid': None,
+                'callback': None,
+                'host_id': '123456',
+            }
+        )
+
+    def test_emit_binary(self):
+        self.pm.emit('foo', b'bar')
+        self.pm._publish.assert_called_once_with(
+            {
+                'method': 'emit',
+                'event': 'foo',
+                'binary': True,
+                'data': [{'_placeholder': True, 'num': 0}, 'YmFy'],
+                'namespace': '/',
+                'room': None,
+                'skip_sid': None,
+                'callback': None,
+                'host_id': '123456',
+            }
+        )
+        self.pm.emit('foo', {'foo': b'bar'})
+        self.pm._publish.assert_called_with(
+            {
+                'method': 'emit',
+                'event': 'foo',
+                'binary': True,
+                'data': [{'foo': {'_placeholder': True, 'num': 0}}, 'YmFy'],
                 'namespace': '/',
                 'room': None,
                 'skip_sid': None,
@@ -85,6 +116,7 @@ class TestPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/',
                 'room': sid,
@@ -100,6 +132,7 @@ class TestPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/baz',
                 'room': None,
@@ -115,6 +148,7 @@ class TestPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/',
                 'room': 'baz',
@@ -130,6 +164,7 @@ class TestPubSubManager:
             {
                 'method': 'emit',
                 'event': 'foo',
+                'binary': False,
                 'data': 'bar',
                 'namespace': '/',
                 'room': None,
@@ -148,6 +183,7 @@ class TestPubSubManager:
                 {
                     'method': 'emit',
                     'event': 'foo',
+                    'binary': False,
                     'data': 'bar',
                     'namespace': '/',
                     'room': 'baz',
@@ -244,6 +280,35 @@ class TestPubSubManager:
             super_emit.assert_called_once_with(
                 'foo',
                 'bar',
+                namespace=None,
+                room=None,
+                skip_sid=None,
+                callback=None,
+            )
+
+    def test_handle_emit_binary(self):
+        with mock.patch.object(manager.Manager, 'emit') as super_emit:
+            self.pm._handle_emit({
+                'event': 'foo',
+                'binary': True,
+                'data': [{'_placeholder': True, 'num': 0}, 'YmFy'],
+            })
+            super_emit.assert_called_once_with(
+                'foo',
+                b'bar',
+                namespace=None,
+                room=None,
+                skip_sid=None,
+                callback=None,
+            )
+            self.pm._handle_emit({
+                'event': 'foo',
+                'binary': True,
+                'data': [{'foo': {'_placeholder': True, 'num': 0}}, 'YmFy'],
+            })
+            super_emit.assert_called_with(
+                'foo',
+                {'foo': b'bar'},
                 namespace=None,
                 room=None,
                 skip_sid=None,


### PR DESCRIPTION
This change restores the ability to send binary messages in setups that use a message queue.

A regression was introduced in #1502, where the encoding used on packets transmitted between hosts in the message queue was switched from pickle to JSON to eliminate the risks associated with the pickle module. Due to the JSON encoding, any messages that included binary data would not send. This change restores the support for binary data, using the same mechanism used to transmit these messages over JSON between server and client.