### PR TITLE
docs: fix example in server.rst with more explicit exception handling

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -248,7 +248,7 @@ message::
 
     @sio.event
     def connect(sid, environ, auth):
-        raise ConnectionRefusedError('authentication failed')
+        raise socketio.exceptions.ConnectionRefusedError('authentication failed')
 
 The disconnect handler receives the ``sid`` assigned to the client and a
 ``reason``, which provides the cause of the disconnection::


### PR DESCRIPTION
[@miguelgrinberg](https://github.com/miguelgrinberg), thank you for this project - it's very useful!

I started using python-socketio in my project but encountered a bug that took me considerable time to debug.

My client wasn't receiving the `connect_error` event, and I tried changing server/client versions, reviewing my code multiple times, and other troubleshooting steps.

Thanks to [this comment](https://github.com/miguelgrinberg/python-socketio/issues/487#issuecomment-2147293485), I was able to identify the issue.

<img width="956" height="455" alt="image" src="https://github.com/user-attachments/assets/a181424c-f960-49ba-8093-f934e2ab5de1" />

I noticed that even in your own test files, you don't use this shortened version anywhere:
```
            side_effect=exceptions.ConnectionRefusedError('fail_reason')
```

Reference: https://github.com/miguelgrinberg/python-socketio/blob/f8a1d435b23df74e720cb1c384955ff5dd1c442c/tests/async/test_server.py#L474C13-L474C73


**Suggestion:** Please update the documentation example to use the full exception name instead of the shortened version.


Using the full module path (e.g., `socketio.exceptions.ConnectionRefusedError`) would make the examples consistent with your own codebase and much clearer for newcomers to understand.Retry


