### PR TITLE
fix recreate binding on failure

### DIFF
--- a/src/socketio/kombu_manager.py
+++ b/src/socketio/kombu_manager.py
@@ -115,10 +115,10 @@ class KombuManager(PubSubManager):  # pragma: no cover
                     break
 
     def _listen(self):
-        reader_queue = self._queue()
         retry_sleep = 1
         while True:
             try:
+                reader_queue = self._queue()
                 with self._connection() as connection:
                     with connection.SimpleQueue(reader_queue) as queue:
                         while True:


### PR DESCRIPTION
# Fix: Recreate RabbitMQ bindings on connection failure

## Fixes

Closes #1469 
Closes #1513 

## Problem

When RabbitMQ goes down and comes back up, the Socket.IO servers enter a **split-brain state** where they can send events but never receive them. This occurs because:

1. Exchange/queue bindings are created **once** before the listening loop
2. When RabbitMQ restarts, these bindings become invalid
3. The retry logic reconnects but **reuses the stale queue/exchange references**
4. Messages can be published (new connections work) but never consumed (old bindings are dead)

This results in servers that appear healthy but silently fail to process incoming events.

## Root Cause

When RabbitMQ goes down and comes back up, Socket.IO servers enter a **split-brain state** where they can send events but never receive them.

## Solution

Move the exchange/queue binding creation inside the retry loop so they are recreated on every connection failure.

## Result

When RabbitMQ restarts, the exception triggers a retry that creates fresh connection, channel, exchange, and queue objects with valid bindings. Servers can now both send and receive events after recovery.